### PR TITLE
generate automatic API docs w/ jsdoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,35 +17,64 @@
 ---
 version: 2.1
 
+orbs:
+  # The Node.js orb contains a set of prepackaged CircleCI configuration you can utilize
+  # Orbs reduce the amount of configuration required for common tasks.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/node
+  node: circleci/node@4.1
+
 jobs:
-  Build test:
+  build-and-test:
     docker:
-      - image: cimg/node:14.13.1
+      - image: cimg/node:15.1
     steps:
       - checkout
+      - node/install-packages
       - run:
-          name: Install the dependencies
-          command: npm install
-      - run:
-          name: Run build test 
+          name: Run build test
           command: npm run test
 
-
-  Code linting:
+  linting:
     docker:
-      - image: cimg/node:14.13.1
+      - image: cimg/node:15.1
     steps:
       - checkout
-      - run:
-          name: Install the dependencies
-          command: npm install
+      - node/install-packages
       - run:
           name: Run linting
           command: npm run lint
+
+  jsdoc-deploy:
+    docker:
+      - image: cimg/node:15.1
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Generate JSDocs
+          command: npm run docs
+      - run:
+          name: Configure git for ci-build
+          command: |
+            git config user.email "ci-build@web-science"
+            git config user.name "ci-build"
+      - add_ssh_keys:
+          fingerprints:
+            - "c2:bb:84:de:5b:fb:f6:7b:90:38:2b:75:ee:b7:bf:59"
+      - run:
+          name: Deploy site to gh-pages branch
+          command: npm run gh-pages
 
 workflows:
   version: 2
   ci:
     jobs:
-      - Build test
-      - Code linting
+      - build-and-test
+      - linting
+      - jsdoc-deploy:
+          requires:
+            - build-and-test
+            - linting
+          filters:
+            branches:
+              only: main

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,28 @@
+{
+    "plugins": [
+        "plugins/markdown"
+    ],
+    "recurseDepth": 10,
+    "source": {
+        "include": [
+            "src/"
+        ],
+        "includePattern": ".+\\.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "sourceType": "module",
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": [
+            "jsdoc",
+            "closure"
+        ]
+    },
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    },
+    "opts": {
+        "destination": "./jsdocs/"
+    }
+}

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -23,6 +23,6 @@
         "monospaceLinks": false
     },
     "opts": {
-        "destination": "./jsdocs/"
+        "destination": "./public/jsdocs/"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-mocha": "^9.0.0",
                 "eslint-plugin-node": "^11.1.0",
+                "gh-pages": "^3.2.3",
                 "globby": "^11.0.0",
                 "js-base64": "^3.6.0",
                 "jsdoc": "^3.6.7",
@@ -472,6 +473,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/array.prototype.flat": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
@@ -496,6 +506,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/async": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.14"
             }
         },
         "node_modules/asynckit": {
@@ -633,6 +652,12 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/commondir": {
             "version": "1.0.1",
@@ -787,6 +812,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/email-addresses": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
+            "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
+            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1413,12 +1444,137 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/filenamify": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+            "dev": true,
+            "dependencies": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+            "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+            "dev": true,
+            "dependencies": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^4.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -1522,6 +1678,65 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gh-pages": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
+            "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+            "dev": true,
+            "dependencies": {
+                "async": "^2.6.1",
+                "commander": "^2.18.0",
+                "email-addresses": "^3.0.1",
+                "filenamify": "^4.3.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^8.1.0",
+                "globby": "^6.1.0"
+            },
+            "bin": {
+                "gh-pages": "bin/gh-pages.js",
+                "gh-pages-clean": "bin/gh-pages-clean.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/gh-pages/node_modules/array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "dependencies": {
+                "array-uniq": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gh-pages/node_modules/globby": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gh-pages/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/glob": {
@@ -2209,6 +2424,30 @@
                 "sourcemap-codec": "^1.4.4"
             }
         },
+        "node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-dir/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/markdown-it": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -2526,6 +2765,15 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
@@ -2737,6 +2985,27 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "dependencies": {
+                "pinkie": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/pkg-dir": {
@@ -3235,6 +3504,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3352,6 +3633,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/tsconfig-paths": {
@@ -3939,6 +4232,12 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
         "array.prototype.flat": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
@@ -3955,6 +4254,15 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
+        },
+        "async": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.14"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -4061,6 +4369,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -4181,6 +4495,12 @@
                     "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
                 }
             }
+        },
+        "email-addresses": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
+            "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
+            "dev": true
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -4672,12 +4992,100 @@
                 "flat-cache": "^3.0.4"
             }
         },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+            "dev": true
+        },
+        "filenamify": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+            "dev": true,
+            "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
+            }
+        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "requires": {
                 "to-regex-range": "^5.0.1"
+            }
+        },
+        "find-cache-dir": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+            "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+                    "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.0.0"
+                    }
+                }
             }
         },
         "find-up": {
@@ -4756,6 +5164,51 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "gh-pages": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
+            "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.1",
+                "commander": "^2.18.0",
+                "email-addresses": "^3.0.1",
+                "filenamify": "^4.3.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^8.1.0",
+                "globby": "^6.1.0"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "glob": {
@@ -5273,6 +5726,23 @@
                 "sourcemap-codec": "^1.4.4"
             }
         },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "requires": {
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
         "markdown-it": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -5518,6 +5988,12 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
         },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
         "object-inspect": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
@@ -5667,6 +6143,21 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
         },
         "pkg-dir": {
             "version": "2.0.0",
@@ -6022,6 +6513,15 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6119,6 +6619,15 @@
             "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
             "requires": {
                 "punycode": "^2.1.1"
+            }
+        },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
             }
         },
         "tsconfig-paths": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "eslint-plugin-node": "^11.1.0",
                 "globby": "^11.0.0",
                 "js-base64": "^3.6.0",
-                "jsdoc": "^3.6.6",
+                "jsdoc": "^3.6.7",
                 "npm-run-all": "^4.1.5",
                 "rollup": "^2.41.4",
                 "rollup-plugin-copy": "^3.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,12 @@
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-mocha": "^9.0.0",
                 "eslint-plugin-node": "^11.1.0",
-                "npm-run-all": "^4.1.5"
+                "globby": "^11.0.0",
+                "js-base64": "^3.6.0",
+                "jsdoc": "^3.6.6",
+                "npm-run-all": "^4.1.5",
+                "rollup": "^2.41.4",
+                "rollup-plugin-copy": "^3.4.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -98,15 +103,6 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -128,16 +124,28 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@babel/parser": {
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+            "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-            "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+            "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
                 "espree": "^7.3.0",
-                "globals": "^13.9.0",
+                "globals": "^12.1.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^3.13.1",
@@ -148,25 +156,29 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.0",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "type-fest": "^0.8.1"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
-            "dev": true
+        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/@mozilla/readability": {
             "version": "0.4.1",
@@ -177,11 +189,11 @@
             }
         },
         "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+            "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
             "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
+                "@nodelib/fs.stat": "2.0.4",
                 "run-parallel": "^1.1.9"
             },
             "engines": {
@@ -189,19 +201,19 @@
             }
         },
         "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+            "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
             "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
+                "@nodelib/fs.scandir": "2.1.4",
                 "fastq": "^1.6.0"
             },
             "engines": {
@@ -310,9 +322,9 @@
             "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
         },
         "node_modules/@types/node": {
-            "version": "15.12.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.1.tgz",
-            "integrity": "sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw=="
+            "version": "15.3.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
         },
         "node_modules/@types/resolve": {
             "version": "1.17.1",
@@ -348,9 +360,9 @@
             }
         },
         "node_modules/acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -496,6 +508,12 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -552,6 +570,18 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/catharsis": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+            "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.15"
+            },
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/chalk": {
@@ -679,9 +709,9 @@
             }
         },
         "node_modules/decimal.js": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
         },
         "node_modules/deep-is": {
             "version": "0.1.3",
@@ -776,6 +806,12 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/entities": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+            "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+            "dev": true
+        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -786,9 +822,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -799,14 +835,14 @@
                 "has-symbols": "^1.0.2",
                 "is-callable": "^1.2.3",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.3",
-                "is-string": "^1.0.6",
-                "object-inspect": "^1.10.3",
+                "is-regex": "^1.1.2",
+                "is-string": "^1.0.5",
+                "object-inspect": "^1.9.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.1"
+                "unbox-primitive": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -833,15 +869,12 @@
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true,
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.8.0"
             }
         },
         "node_modules/escodegen": {
@@ -921,14 +954,13 @@
             }
         },
         "node_modules/eslint": {
-            "version": "7.31.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-            "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+            "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.3",
-                "@humanwhocodes/config-array": "^0.5.0",
+                "@eslint/eslintrc": "^0.4.1",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -945,7 +977,7 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.1.2",
+                "glob-parent": "^5.0.0",
                 "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
@@ -1215,6 +1247,18 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/eslint/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/espree": {
@@ -1511,9 +1555,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.10.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-            "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+            "version": "13.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -1526,9 +1570,9 @@
             }
         },
         "node_modules/globby": {
-            "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -1923,6 +1967,52 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/js2xmlparser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+            "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+            "dev": true,
+            "dependencies": {
+                "xmlcreate": "^2.0.3"
+            }
+        },
+        "node_modules/jsdoc": {
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+            "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.9.4",
+                "bluebird": "^3.7.2",
+                "catharsis": "^0.9.0",
+                "escape-string-regexp": "^2.0.0",
+                "js2xmlparser": "^4.0.1",
+                "klaw": "^3.0.0",
+                "markdown-it": "^10.0.0",
+                "markdown-it-anchor": "^5.2.7",
+                "marked": "^2.0.3",
+                "mkdirp": "^1.0.4",
+                "requizzle": "^0.2.3",
+                "strip-json-comments": "^3.1.0",
+                "taffydb": "2.6.2",
+                "underscore": "~1.13.1"
+            },
+            "bin": {
+                "jsdoc": "jsdoc.js"
+            },
+            "engines": {
+                "node": ">=8.15.0"
+            }
+        },
+        "node_modules/jsdoc/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jsdom": {
             "version": "16.6.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
@@ -1969,9 +2059,9 @@
             }
         },
         "node_modules/jsdom/node_modules/acorn": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz",
-            "integrity": "sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+            "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2017,6 +2107,15 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/klaw": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2028,6 +2127,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "dependencies": {
+                "uc.micro": "^1.0.1"
             }
         },
         "node_modules/load-json-file": {
@@ -2101,6 +2209,49 @@
                 "sourcemap-codec": "^1.4.4"
             }
         },
+        "node_modules/markdown-it": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "entities": "~2.0.0",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it-anchor": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+            "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+            "dev": true,
+            "peerDependencies": {
+                "markdown-it": "*"
+            }
+        },
+        "node_modules/marked": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.6.tgz",
+            "integrity": "sha512-S2mYj0FzTQa0dLddssqwRVW4EOJOVJ355Xm2Vcbm+LU7GQRGWvwbO5K87OaPSOux2AwTSgtPPaXmc8sDPrhn2A==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked"
+            },
+            "engines": {
+                "node": ">= 8.16.2"
+            }
+        },
+        "node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
+        },
         "node_modules/memorystream": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -2165,6 +2316,18 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -2286,15 +2449,6 @@
                 "node": ">=4.8"
             }
         },
-        "node_modules/npm-run-all/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/npm-run-all/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2409,14 +2563,15 @@
             }
         },
         "node_modules/object.values": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-            "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+            "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.2"
+                "es-abstract": "^1.18.0-next.2",
+                "has": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2540,9 +2695,9 @@
             }
         },
         "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -2553,9 +2708,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "engines": {
                 "node": ">=8.6"
             },
@@ -2724,6 +2879,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/requizzle": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+            "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.14"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -2770,9 +2934,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.53.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.2.tgz",
-            "integrity": "sha512-1CtEYuS5CRCzFZ7SNW5528SlDlk4VDXIRGwbm/2POQxA/G4+7/crIqJwkmnj8Q/74hGx4oVlNvh4E1CJQ5hZ6w==",
+            "version": "2.50.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.5.tgz",
+            "integrity": "sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==",
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -2780,7 +2944,7 @@
                 "node": ">=10.0.0"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.1"
             }
         },
         "node_modules/rollup-plugin-copy": {
@@ -2970,9 +3134,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-            "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
             "dev": true
         },
         "node_modules/sprintf-js": {
@@ -3106,9 +3270,9 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-            "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+            "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -3125,6 +3289,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
+        },
+        "node_modules/taffydb": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+            "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
             "dev": true
         },
         "node_modules/text-table": {
@@ -3220,6 +3390,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -3234,6 +3410,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/underscore": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "0.1.2",
@@ -3317,12 +3499,12 @@
             "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
         },
         "node_modules/whatwg-url": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-            "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
             "dependencies": {
                 "lodash": "^4.7.0",
-                "tr46": "^2.0.2",
+                "tr46": "^2.1.0",
                 "webidl-conversions": "^6.1.0"
             },
             "engines": {
@@ -3374,9 +3556,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+            "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -3402,6 +3584,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+        },
+        "node_modules/xmlcreate": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+            "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+            "dev": true
         },
         "node_modules/yallist": {
             "version": "4.0.0",
@@ -3472,12 +3660,6 @@
                     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
                     "dev": true
                 },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                    "dev": true
-                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3495,39 +3677,45 @@
                 }
             }
         },
+        "@babel/parser": {
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+            "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+            "dev": true
+        },
         "@eslint/eslintrc": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-            "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+            "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
                 "espree": "^7.3.0",
-                "globals": "^13.9.0",
+                "globals": "^12.1.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                    "dev": true
+                }
             }
-        },
-        "@humanwhocodes/config-array": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-            "dev": true,
-            "requires": {
-                "@humanwhocodes/object-schema": "^1.2.0",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
-            }
-        },
-        "@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
-            "dev": true
         },
         "@mozilla/readability": {
             "version": "0.4.1",
@@ -3535,25 +3723,25 @@
             "integrity": "sha512-yar/f0w0fRUVM895s6yd5Z2oIxjG/6c3ROB/uQboSOBaDlri/nqI4aKtdqrldWciTLcdpjB2Z6MiVF2Bl9b8LA=="
         },
         "@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+            "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
             "requires": {
-                "@nodelib/fs.stat": "2.0.5",
+                "@nodelib/fs.stat": "2.0.4",
                 "run-parallel": "^1.1.9"
             }
         },
         "@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
         },
         "@nodelib/fs.walk": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+            "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
             "requires": {
-                "@nodelib/fs.scandir": "2.1.5",
+                "@nodelib/fs.scandir": "2.1.4",
                 "fastq": "^1.6.0"
             }
         },
@@ -3640,9 +3828,9 @@
             "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
         },
         "@types/node": {
-            "version": "15.12.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.1.tgz",
-            "integrity": "sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw=="
+            "version": "15.3.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
         },
         "@types/resolve": {
             "version": "1.17.1",
@@ -3672,9 +3860,9 @@
             }
         },
         "acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
             "dev": true,
             "requires": {}
         },
@@ -3778,6 +3966,12 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
+        "bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3820,6 +4014,15 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
+        },
+        "catharsis": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+            "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
         },
         "chalk": {
             "version": "4.1.1",
@@ -3919,9 +4122,9 @@
             }
         },
         "decimal.js": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
         },
         "deep-is": {
             "version": "0.1.3",
@@ -3994,6 +4197,12 @@
                 "ansi-colors": "^4.1.1"
             }
         },
+        "entities": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+            "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+            "dev": true
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4004,9 +4213,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -4017,14 +4226,14 @@
                 "has-symbols": "^1.0.2",
                 "is-callable": "^1.2.3",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.3",
-                "is-string": "^1.0.6",
-                "object-inspect": "^1.10.3",
+                "is-regex": "^1.1.2",
+                "is-string": "^1.0.5",
+                "object-inspect": "^1.9.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.1"
+                "unbox-primitive": "^1.0.0"
             }
         },
         "es-to-primitive": {
@@ -4039,9 +4248,9 @@
             }
         },
         "escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
         "escodegen": {
@@ -4099,14 +4308,13 @@
             }
         },
         "eslint": {
-            "version": "7.31.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-            "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+            "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.3",
-                "@humanwhocodes/config-array": "^0.5.0",
+                "@eslint/eslintrc": "^0.4.1",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -4123,7 +4331,7 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.1.2",
+                "glob-parent": "^5.0.0",
                 "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
@@ -4144,6 +4352,14 @@
                 "table": "^6.0.9",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                }
             }
         },
         "eslint-import-resolver-node": {
@@ -4564,18 +4780,18 @@
             }
         },
         "globals": {
-            "version": "13.10.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-            "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+            "version": "13.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
             }
         },
         "globby": {
-            "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -4852,6 +5068,45 @@
                 "esprima": "^4.0.0"
             }
         },
+        "js2xmlparser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+            "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+            "dev": true,
+            "requires": {
+                "xmlcreate": "^2.0.3"
+            }
+        },
+        "jsdoc": {
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+            "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.9.4",
+                "bluebird": "^3.7.2",
+                "catharsis": "^0.9.0",
+                "escape-string-regexp": "^2.0.0",
+                "js2xmlparser": "^4.0.1",
+                "klaw": "^3.0.0",
+                "markdown-it": "^10.0.0",
+                "markdown-it-anchor": "^5.2.7",
+                "marked": "^2.0.3",
+                "mkdirp": "^1.0.4",
+                "requizzle": "^0.2.3",
+                "strip-json-comments": "^3.1.0",
+                "taffydb": "2.6.2",
+                "underscore": "~1.13.1"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
+            }
+        },
         "jsdom": {
             "version": "16.6.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
@@ -4887,9 +5142,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz",
-                    "integrity": "sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw=="
+                    "version": "8.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+                    "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
                 }
             }
         },
@@ -4928,6 +5183,15 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "klaw": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
         "levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4936,6 +5200,15 @@
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
+            }
+        },
+        "linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "requires": {
+                "uc.micro": "^1.0.1"
             }
         },
         "load-json-file": {
@@ -5000,6 +5273,38 @@
                 "sourcemap-codec": "^1.4.4"
             }
         },
+        "markdown-it": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "entities": "~2.0.0",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            }
+        },
+        "markdown-it-anchor": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+            "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+            "dev": true,
+            "requires": {}
+        },
+        "marked": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.6.tgz",
+            "integrity": "sha512-S2mYj0FzTQa0dLddssqwRVW4EOJOVJ355Xm2Vcbm+LU7GQRGWvwbO5K87OaPSOux2AwTSgtPPaXmc8sDPrhn2A==",
+            "dev": true
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
+        },
         "memorystream": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -5045,6 +5350,12 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true
         },
         "ms": {
@@ -5149,12 +5460,6 @@
                         "which": "^1.2.9"
                     }
                 },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                    "dev": true
-                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5238,14 +5543,15 @@
             }
         },
         "object.values": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-            "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+            "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.2"
+                "es-abstract": "^1.18.0-next.2",
+                "has": "^1.0.3"
             }
         },
         "once": {
@@ -5336,9 +5642,9 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-type": {
             "version": "4.0.0",
@@ -5346,9 +5652,9 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
         },
         "pidtree": {
             "version": "0.3.1",
@@ -5457,6 +5763,15 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
         },
+        "requizzle": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+            "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.14"
+            }
+        },
         "resolve": {
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -5487,11 +5802,11 @@
             }
         },
         "rollup": {
-            "version": "2.53.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.2.tgz",
-            "integrity": "sha512-1CtEYuS5CRCzFZ7SNW5528SlDlk4VDXIRGwbm/2POQxA/G4+7/crIqJwkmnj8Q/74hGx4oVlNvh4E1CJQ5hZ6w==",
+            "version": "2.50.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.5.tgz",
+            "integrity": "sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==",
             "requires": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.1"
             }
         },
         "rollup-plugin-copy": {
@@ -5633,9 +5948,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-            "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
             "dev": true
         },
         "sprintf-js": {
@@ -5736,9 +6051,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-                    "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+                    "version": "8.4.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+                    "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -5754,6 +6069,12 @@
                     "dev": true
                 }
             }
+        },
+        "taffydb": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+            "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+            "dev": true
         },
         "text-table": {
             "version": "0.2.0",
@@ -5827,6 +6148,12 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
         },
+        "uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
         "unbox-primitive": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -5838,6 +6165,12 @@
                 "has-symbols": "^1.0.2",
                 "which-boxed-primitive": "^1.0.2"
             }
+        },
+        "underscore": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+            "dev": true
         },
         "universalify": {
             "version": "0.1.2",
@@ -5909,12 +6242,12 @@
             "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
         },
         "whatwg-url": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-            "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
             "requires": {
                 "lodash": "^4.7.0",
-                "tr46": "^2.0.2",
+                "tr46": "^2.1.0",
                 "webidl-conversions": "^6.1.0"
             }
         },
@@ -5951,9 +6284,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+            "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
             "requires": {}
         },
         "xml-name-validator": {
@@ -5965,6 +6298,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+        },
+        "xmlcreate": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+            "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+            "dev": true
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "eslint-plugin-node": "^11.1.0",
         "globby": "^11.0.0",
         "js-base64": "^3.6.0",
-        "jsdoc": "^3.6.6",
+        "jsdoc": "^3.6.7",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.41.4",
         "rollup-plugin-copy": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "scripts": {
         "build": "rollup -c rollup.config.intermediate.js && rollup -c rollup.config.final.js",
         "lint": "eslint .",
-        "docs": "jsdoc -c .jsdoc.json"
+        "test": "cd tests/build/ && rollup -c",
+        "docs": "jsdoc -c .jsdoc.json",
+        "gh-pages": "gh-pages --dist public"
     },
     "dependencies": {
         "@mozilla/readability": "^0.4.1",
@@ -23,6 +25,7 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-node": "^11.1.0",
+        "gh-pages": "^3.2.3",
         "globby": "^11.0.0",
         "js-base64": "^3.6.0",
         "jsdoc": "^3.6.7",

--- a/package.json
+++ b/package.json
@@ -2,27 +2,33 @@
     "name": "@mozilla/web-science",
     "version": "0.4.0",
     "scripts": {
+        "build": "rollup -c rollup.config.intermediate.js && rollup -c rollup.config.final.js",
         "lint": "eslint .",
-        "test": "cd tests/build/ && rollup -c"
+        "docs": "jsdoc -c .jsdoc.json"
     },
     "dependencies": {
-        "rollup": "^2.41.4",
+        "@mozilla/readability": "^0.4.1",
         "@rollup/plugin-commonjs": "19.0.1",
         "@rollup/plugin-node-resolve": "^13.0.0",
-        "rollup-plugin-copy": "^3.4.0",
         "globby": "^11.0.0",
-        "@mozilla/readability": "^0.4.1",
         "js-base64": "^3.6.0",
+        "jsdom": "^16.6.0",
+        "rollup": "^2.41.4",
+        "rollup-plugin-copy": "^3.4.0",
         "tldts": "^5.7.25",
-        "uuid": "^8.3.2",
-        "jsdom": "^16.6.0"
+        "uuid": "^8.3.2"
     },
     "devDependencies": {
         "eslint": "^7.22.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-node": "^11.1.0",
-        "npm-run-all": "^4.1.5"
+        "globby": "^11.0.0",
+        "js-base64": "^3.6.0",
+        "jsdoc": "^3.6.6",
+        "npm-run-all": "^4.1.5",
+        "rollup": "^2.41.4",
+        "rollup-plugin-copy": "^3.4.0"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<head>
+    <title>WebScience</title>
+</head>
+
+<body>
+    <a href="jsdocs">API docs</a>
+</body>
+
+</html>

--- a/src/matching.js
+++ b/src/matching.js
@@ -82,7 +82,7 @@ const allUrlsRegExpString = "^(?:(?:(?:https?)|(?:wss?)|(?:ftp))://[?[a-zA-Z0-9\
  * Parses a match pattern string into an object that represents the match pattern. We use this internal,
  * intermediate representation to enable constructing efficient matching objects. The parsing logic is
  * nearly identical to the parsing logic in Firefox.
- * @throws {Exception} Throws an error if the match pattern is not valid.
+ * @throws Throws an error if the match pattern is not valid.
  * @param {string} matchPattern - The match pattern string.
  * @returns {ParsedMatchPattern} - The parsed match pattern.
  * @see {@link https://searchfox.org/mozilla-central/source/toolkit/components/extensions/MatchPattern.cpp}
@@ -441,7 +441,7 @@ function parsedMatchPatternToRegExpString(parsedMatchPattern) {
 
 /**
  * Converts a match pattern into a regular expression string.
- * @throws {Exception} Throws an error if the match pattern is not valid.
+ * @throws Throws an error if the match pattern is not valid.
  * @param {string} matchPattern - The match pattern.
  * @returns {string} The regular expression.
  * @private
@@ -462,7 +462,7 @@ function combineRegExpStrings(regExpStrings) {
 
 /**
  * Converts an array of match patterns into a regular expression string.
-* @throws {Exception} Throws an error if the match pattern is not valid.
+ * @throws Throws an error if the match pattern is not valid.
  * @param {string[]} matchPatterns - The match patterns.
  * @returns {string} The regular expression string.
  */
@@ -472,7 +472,7 @@ export function matchPatternsToRegExpString(matchPatterns) {
 
 /**
  * Converts an array of match patterns into a RegExp object.
-* @throws {Exception} Throws an error if the match pattern is not valid.
+ * @throws Throws an error if the match pattern is not valid.
  * @param {string[]} matchPatterns - The match patterns.
  * @returns {RegExp} The regular expression RegExp object.
  */
@@ -528,7 +528,7 @@ export function domainsToRegExp(domains, matchSubdomains = true) {
  *   * Remove the fragment identifier, if any. For example, https://www.mozilla.org/#foo becomes https://www.mozilla.org/.
  * @param {string} url - The URL string to normalize.
  * @return {string} The normalized URL string.
-*  @throws {Exception} Throws an error if the match pattern is not valid, absolute URL.
+ * @throws Throws an error if the match pattern is not valid, absolute URL.
  */
 export function normalizeUrl(url) {
     const urlObj = new URL(url);

--- a/src/matching.js
+++ b/src/matching.js
@@ -82,7 +82,7 @@ const allUrlsRegExpString = "^(?:(?:(?:https?)|(?:wss?)|(?:ftp))://[?[a-zA-Z0-9\
  * Parses a match pattern string into an object that represents the match pattern. We use this internal,
  * intermediate representation to enable constructing efficient matching objects. The parsing logic is
  * nearly identical to the parsing logic in Firefox.
- * @throws {Error} Throws an error if the match pattern is not valid.
+ * @throws {Exception} Throws an error if the match pattern is not valid.
  * @param {string} matchPattern - The match pattern string.
  * @returns {ParsedMatchPattern} - The parsed match pattern.
  * @see {@link https://searchfox.org/mozilla-central/source/toolkit/components/extensions/MatchPattern.cpp}
@@ -441,7 +441,7 @@ function parsedMatchPatternToRegExpString(parsedMatchPattern) {
 
 /**
  * Converts a match pattern into a regular expression string.
- * @throws {Error} Throws an error if the match pattern is not valid.
+ * @throws {Exception} Throws an error if the match pattern is not valid.
  * @param {string} matchPattern - The match pattern.
  * @returns {string} The regular expression.
  * @private
@@ -462,7 +462,7 @@ function combineRegExpStrings(regExpStrings) {
 
 /**
  * Converts an array of match patterns into a regular expression string.
- * @throws {Error} Throws an error if a match pattern is not valid.
+* @throws {Exception} Throws an error if the match pattern is not valid.
  * @param {string[]} matchPatterns - The match patterns.
  * @returns {string} The regular expression string.
  */
@@ -472,7 +472,7 @@ export function matchPatternsToRegExpString(matchPatterns) {
 
 /**
  * Converts an array of match patterns into a RegExp object.
- * @throws {Error} Throws an error if a match pattern is not valid.
+* @throws {Exception} Throws an error if the match pattern is not valid.
  * @param {string[]} matchPatterns - The match patterns.
  * @returns {RegExp} The regular expression RegExp object.
  */
@@ -527,8 +527,8 @@ export function domainsToRegExp(domains, matchSubdomains = true) {
  *   * Remove query parameters, if any. For example, https://www.mozilla.org/?foo becomes https://www.mozilla.org/.
  *   * Remove the fragment identifier, if any. For example, https://www.mozilla.org/#foo becomes https://www.mozilla.org/.
  * @param {string} url - The URL string to normalize.
- * @returns {string} The normalized URL string.
- * @throws {Error} Throws an error if the URL string is not a valid, absolute URL.
+ * @return {string} The normalized URL string.
+*  @throws {Exception} Throws an error if the match pattern is not valid, absolute URL.
  */
 export function normalizeUrl(url) {
     const urlObj = new URL(url);


### PR DESCRIPTION
This adds an `npm run docs` command to generate API docs using jsdoc, it creates a `./jsdoc` directory for this.

- [x] add npm command to generate jsdoc
- [x] set up CircleCI to push to GH docs