### PR TITLE
0.1.0 release branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-    "name": "web-science",
-    "version": "0.0.1",
+    "name": "@mozilla/web-science",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.1",
+            "name": "@mozilla/web-science",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@mozilla/readability": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mozilla/web-science",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "scripts": {
         "build": "rollup -c rollup.config.intermediate.js && rollup -c rollup.config.final.js",
         "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "keywords": [],
     "author": "Princeton University Researchers and Mozilla",
     "license": "Apache-2.0",
-    "private": true,
+    "private": false,
     "bugs": {
         "url": "https://github.com/mozilla-rally/web-science/issues"
     },


### PR DESCRIPTION
We don't have a documented release process for WebScience yet, for starters I just made this branch and [pushed a 0.1.0 pre-release to npm](https://www.npmjs.com/package/@mozilla/web-science). I'm planning to tag after we merge this branch to `main`, normally I think we'd want to merge+tag first but I was assuming I had to tweak things to get it to work on npm (which turned out to be true!)

The rally core add-on has a [documented release process](https://github.com/mozilla-rally/rally-core-addon/blob/master/docs/RELEASE_PROCESS.md), it's probably a little heavier than WebScience needs necessarily, but something to consider.