### PR TITLE
Add tabId and openerTabId data to PageTransitionDataDetails

### DIFF
--- a/src/content-scripts/pageTransition.event.content.js
+++ b/src/content-scripts/pageTransition.event.content.js
@@ -128,8 +128,8 @@
          * property from this module's click content script and background script. The cached page
          * visits are from the same tab as this page or, if the page is opened in a new tab, the cached
          * page visits are from the opener tab.
-         * @param {boolean} message.isOpenedTab - Whether the page is loading in a new tab that was
-         * opened by another tab.
+         * @property {number} message.openerTabId - If the page is loading in a tab that was newly
+         * opened from another tab, the tab ID of the opening tab. Otherwise -1.
          * @param {number} message.tabOpeningTimeStamp - The timestamp of when this page's tab was
          * opened, if the page is loading in a new tab that was opened by another tab. Otherwise 0.
          * @returns {boolean} Whether the background script update message was successfully used to
@@ -143,7 +143,7 @@
             isHistoryChange,
             pageVisitTimeCache,
             cachedPageVisitsForTab,
-            isOpenedTab,
+            openerTabId,
             tabOpeningTimeStamp
         }) {
             // If no page visit has started, this must be a background script update
@@ -248,7 +248,7 @@
                 // have a race condition where tab 1 opens tab 2, the page in tab 2 is slow to load, tab 1
                 // navigates to another page, then we incorrectly associate the new page in tab 2 with the later
                 // page in tab 1.
-                const pageVisitComparisonTime = isOpenedTab ? tabOpeningTimeStamp : pageManager.pageVisitStartTime;
+                const pageVisitComparisonTime = openerTabId !== -1 ? tabOpeningTimeStamp : pageManager.pageVisitStartTime;
                 for(const cachePageId in cachedPageVisitsForTab) {
                     // Ignore pages that started after this page started or, if this is a tab newly opened by 
                     // another tab, ignore pages that started after this tab was opened
@@ -305,7 +305,7 @@
                 pageId: pageManager.pageId,
                 url: pageManager.url,
                 isHistoryChange,
-                isOpenedTab,
+                openerTabId,
                 transitionType: transitionType,
                 transitionQualifiers: transitionQualifiers,
                 tabSourcePageId,

--- a/src/content-scripts/pageTransition.event.content.js
+++ b/src/content-scripts/pageTransition.event.content.js
@@ -131,7 +131,8 @@
          * @param {boolean} message.isOpenedTab - Whether the page is loading in a new tab that was
          * opened by another tab.
          * @property {number} message.openerTabId - If the page is loading in a tab that was newly
-         * opened from another tab, the tab ID of the opening tab. Otherwise -1.
+         * opened from another tab (i.e., `isOpenedTab` is `true`), the tab ID of the opener tab.
+         * Otherwise, `tabs.TAB_ID_NONE`.
          * @param {number} message.tabOpeningTimeStamp - The timestamp of when this page's tab was
          * opened, if the page is loading in a new tab that was opened by another tab. Otherwise 0.
          * @returns {boolean} Whether the background script update message was successfully used to

--- a/src/content-scripts/pageTransition.event.content.js
+++ b/src/content-scripts/pageTransition.event.content.js
@@ -128,6 +128,8 @@
          * property from this module's click content script and background script. The cached page
          * visits are from the same tab as this page or, if the page is opened in a new tab, the cached
          * page visits are from the opener tab.
+         * @param {boolean} message.isOpenedTab - Whether the page is loading in a new tab that was
+         * opened by another tab.
          * @property {number} message.openerTabId - If the page is loading in a tab that was newly
          * opened from another tab, the tab ID of the opening tab. Otherwise -1.
          * @param {number} message.tabOpeningTimeStamp - The timestamp of when this page's tab was
@@ -143,6 +145,7 @@
             isHistoryChange,
             pageVisitTimeCache,
             cachedPageVisitsForTab,
+            isOpenedTab,
             openerTabId,
             tabOpeningTimeStamp
         }) {
@@ -248,7 +251,7 @@
                 // have a race condition where tab 1 opens tab 2, the page in tab 2 is slow to load, tab 1
                 // navigates to another page, then we incorrectly associate the new page in tab 2 with the later
                 // page in tab 1.
-                const pageVisitComparisonTime = openerTabId !== -1 ? tabOpeningTimeStamp : pageManager.pageVisitStartTime;
+                const pageVisitComparisonTime = isOpenedTab ? tabOpeningTimeStamp : pageManager.pageVisitStartTime;
                 for(const cachePageId in cachedPageVisitsForTab) {
                     // Ignore pages that started after this page started or, if this is a tab newly opened by 
                     // another tab, ignore pages that started after this tab was opened
@@ -305,6 +308,7 @@
                 pageId: pageManager.pageId,
                 url: pageManager.url,
                 isHistoryChange,
+                isOpenedTab,
                 openerTabId,
                 transitionType: transitionType,
                 transitionQualifiers: transitionQualifiers,

--- a/src/pageManager.js
+++ b/src/pageManager.js
@@ -153,7 +153,9 @@ const considerUserInputForAttention = true;
  * Additional information about a page visit start event.
  * @typedef {Object} PageVisitStartDetails
  * @param {string} pageId - The ID for the page, unique across browsing sessions.
- * @param {number} tabId - The ID for the tab containing the page, unique to the browsing session.
+ * @param {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
+ * using this value to send a message to a content script on the page, we recommend also sending pageId for
+ * the content script to check in order to avoid possible race conditions.
  * @param {number} windowId - The ID for the window containing the page, unique to the browsing session.
  * Note that tabs can subsequently move between windows.
  * @param {string} url - The URL of the page loading in the tab, without any hash.

--- a/src/pageManager.js
+++ b/src/pageManager.js
@@ -155,9 +155,9 @@ const considerUserInputForAttention = true;
  * @param {string} pageId - The ID for the page, unique across browsing sessions.
  * @param {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
  * you send a message to the content script in the tab, there is a possible race condition where the page in 
- * the tab changes before your message arrives. You should specify a page ID in your message to the content 
- * script, and the content script should check that page ID against its current page ID to ensure that the 
- * message was received by the intended page.
+ * the tab changes before your message arrives. You should specify a page ID (e.g., `pageId`) in your message to
+ * the content script, and the content script should check that page ID against its current page ID to ensure that
+ * the message was received by the intended page.
  * @param {number} windowId - The ID for the window containing the page, unique to the browsing session.
  * Note that tabs can subsequently move between windows.
  * @param {string} url - The URL of the page loading in the tab, without any hash.

--- a/src/pageManager.js
+++ b/src/pageManager.js
@@ -154,8 +154,10 @@ const considerUserInputForAttention = true;
  * @typedef {Object} PageVisitStartDetails
  * @param {string} pageId - The ID for the page, unique across browsing sessions.
  * @param {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
- * using this value to send a message to a content script on the page, we recommend also sending pageId for the
- * content script to check against its current pageId in order to avoid possible race conditions.
+ * you send a message to the content script in the tab, there is a possible race condition where the page in 
+ * the tab changes before your message arrives. You should specify a page ID in your message to the content 
+ * script, and the content script should check that page ID against its current page ID to ensure that the 
+ * message was received by the intended page.
  * @param {number} windowId - The ID for the window containing the page, unique to the browsing session.
  * Note that tabs can subsequently move between windows.
  * @param {string} url - The URL of the page loading in the tab, without any hash.

--- a/src/pageManager.js
+++ b/src/pageManager.js
@@ -154,8 +154,8 @@ const considerUserInputForAttention = true;
  * @typedef {Object} PageVisitStartDetails
  * @param {string} pageId - The ID for the page, unique across browsing sessions.
  * @param {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
- * using this value to send a message to a content script on the page, we recommend also sending pageId for
- * the content script to check in order to avoid possible race conditions.
+ * using this value to send a message to a content script on the page, we recommend also sending pageId for the
+ * content script to check against its current pageId in order to avoid possible race conditions.
  * @param {number} windowId - The ID for the window containing the page, unique to the browsing session.
  * Note that tabs can subsequently move between windows.
  * @param {string} url - The URL of the page loading in the tab, without any hash.

--- a/src/pageTransition.js
+++ b/src/pageTransition.js
@@ -156,16 +156,19 @@ permissions.check({
  * @property {string} url - The URL of the page, without any hash.
  * @property {string} referrer - The referrer URL for the page, or `""` if there is no referrer. Note that we
  * recommend against using referrers for analyzing page transitions.
- * @property {number} tabId - The ID of the tab that the page is loaded in. Can be used to send messages to the
- * page's content scripts. Note that if using this value to send a message to a content script on the page, we
- * recommend also sending pageId for the content script to check against its current pageId in order to avoid
- * possible race conditions.
+ * @property {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
+ * you send a message to the content script in the tab, there is a possible race condition where the page in 
+ * the tab changes before your message arrives. You should specify a page ID in your message to the content 
+ * script, and the content script should check that page ID against its current page ID to ensure that the 
+ * message was received by the intended page.
  * @property {boolean} isHistoryChange - Whether the page transition was caused by a URL change via the History API.
  * @property {boolean} isOpenedTab - Whether the page is loading in a tab that was newly opened from another tab.
- * @property {number} openerTabId - If the page is loading in a tab that was newly opened from another tab, the tab
- * ID of the opening tab. Otherwise -1. Note that if using this value to send a message to a content script on
- * the opening page, we recommend also sending tabSourcePageId for the content script to check against its current
- * pageId in order to avoid possible race conditions.
+ * @property {number} openerTabId - If the page is loading in a tab that was newly opened from another tab
+ * (i.e., `isOpenedTab` is `true`), the tab ID of the opener tab. Otherwise, `tabs.TAB_ID_NONE`. Note that if
+ * you send a message to the content script in the tab, there is a possible race condition where the page in 
+ * the tab changes before your message arrives. You should specify a page ID (tabSourcePageId in this case) in your
+ * message to the content script, and the content script should check that page ID against its current page ID to
+ * ensure that the message was received by the intended page.
  * @property {string} transitionType - The transition type, from `webNavigation.onCommitted` or
  * `webNavigation.onHistoryStateUpdated`.
  * @property {string[]} transitionQualifiers - The transition qualifiers, from `webNavigation.onCommitted` or

--- a/src/pageTransition.js
+++ b/src/pageTransition.js
@@ -158,12 +158,13 @@ permissions.check({
  * recommend against using referrers for analyzing page transitions.
  * @property {number} tabId - The ID of the tab that the page is loaded in. Can be used to send messages to the
  * page's content scripts. Note that if using this value to send a message to a content script on the page, we
- * recommend also sending pageId for the content script to check in order to avoid possible race conditions.
+ * recommend also sending pageId for the content script to check against its current pageId in order to avoid
+ * possible race conditions.
  * @property {boolean} isHistoryChange - Whether the page transition was caused by a URL change via the History API.
  * @property {number} openerTabId - If the page is loading in a tab that was newly opened from another tab, the tab
  * ID of the opening tab. Otherwise -1. Note that if using this value to send a message to a content script on
- * the opening page, we recommend also sending tabSourcePageId for the content script to check in order to avoid
- * possible race conditions.
+ * the opening page, we recommend also sending tabSourcePageId for the content script to check against its current
+ * pageId in order to avoid possible race conditions.
  * @property {string} transitionType - The transition type, from `webNavigation.onCommitted` or
  * `webNavigation.onHistoryStateUpdated`.
  * @property {string[]} transitionQualifiers - The transition qualifiers, from `webNavigation.onCommitted` or

--- a/src/pageTransition.js
+++ b/src/pageTransition.js
@@ -157,10 +157,13 @@ permissions.check({
  * @property {string} referrer - The referrer URL for the page, or `""` if there is no referrer. Note that we
  * recommend against using referrers for analyzing page transitions.
  * @property {number} tabId - The ID of the tab that the page is loaded in. Can be used to send messages to the
- * page's content scripts.
+ * page's content scripts. Note that if using this value to send a message to a content script on the page, we
+ * recommend also sending pageId for the content script to check in order to avoid possible race conditions.
  * @property {boolean} isHistoryChange - Whether the page transition was caused by a URL change via the History API.
  * @property {number} openerTabId - If the page is loading in a tab that was newly opened from another tab, the tab
- * ID of the opening tab. Otherwise -1.
+ * ID of the opening tab. Otherwise -1. Note that if using this value to send a message to a content script on
+ * the opening page, we recommend also sending tabSourcePageId for the content script to check in order to avoid
+ * possible race conditions.
  * @property {string} transitionType - The transition type, from `webNavigation.onCommitted` or
  * `webNavigation.onHistoryStateUpdated`.
  * @property {string[]} transitionQualifiers - The transition qualifiers, from `webNavigation.onCommitted` or

--- a/src/pageTransition.js
+++ b/src/pageTransition.js
@@ -158,15 +158,15 @@ permissions.check({
  * recommend against using referrers for analyzing page transitions.
  * @property {number} tabId - The ID for the tab containing the page, unique to the browsing session. Note that if
  * you send a message to the content script in the tab, there is a possible race condition where the page in 
- * the tab changes before your message arrives. You should specify a page ID in your message to the content 
- * script, and the content script should check that page ID against its current page ID to ensure that the 
+ * the tab changes before your message arrives. You should specify a page ID (e.g., `pageId`) in your message to the
+ * content script, and the content script should check that page ID against its current page ID to ensure that the 
  * message was received by the intended page.
  * @property {boolean} isHistoryChange - Whether the page transition was caused by a URL change via the History API.
  * @property {boolean} isOpenedTab - Whether the page is loading in a tab that was newly opened from another tab.
  * @property {number} openerTabId - If the page is loading in a tab that was newly opened from another tab
  * (i.e., `isOpenedTab` is `true`), the tab ID of the opener tab. Otherwise, `tabs.TAB_ID_NONE`. Note that if
  * you send a message to the content script in the tab, there is a possible race condition where the page in 
- * the tab changes before your message arrives. You should specify a page ID (tabSourcePageId in this case) in your
+ * the tab changes before your message arrives. You should specify a page ID (e.g., `tabSourcePageId`) in your
  * message to the content script, and the content script should check that page ID against its current page ID to
  * ensure that the message was received by the intended page.
  * @property {string} transitionType - The transition type, from `webNavigation.onCommitted` or
@@ -179,8 +179,9 @@ permissions.check({
  * is opening in a new tab, then the URL of the most recent page in the opener tab. The value is `""` if there is no
  * such page.
  * @property {boolean} tabSourceClick - Whether the user recently clicked or pressed enter/return on the most recent
- * page in the same tab. If the page is opening in a new tab, then whether the user  URL of the most recent page in
- * the opener tab. The value is `false` if there is no such page.
+ * page in the same tab. If the page is loading in a tab that was newly opened by another tab, then whether the user
+ * recently clicked or pressed enter/return on the most recent page in the opener tab. The value is `false` if there
+ * is no such page.
  * @property {string} timeSourcePageId - The ID for the most recent page that loaded into any tab. If this is the
  * first page visit after the extension starts, the value is "". Note that we recommend against using time-based
  * page transition data.


### PR DESCRIPTION
In `pageTransition.js` module, added `tabId` and `openerTabId` in `PageTransitionDataDetails`. The properties can be used to message a tab with information about a page transition.

Both `tabId` and `openerTabId` properties of `PageTransitionDataDetails` have notes saying to also send corresponding page ID information if messaging a page's content script so that the content script can check the page ID in order to avoid possible race conditions. Also added a corresponding note to the `PageVisitStartDetails.tabId` description in the `pageManager.js` module.