### PR TITLE
Implement Fathom page classification module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-mocha": "^8.1.0",
                 "eslint-plugin-node": "^11.1.0",
+                "fathom-web": "^3.7.3",
                 "globby": "^11.0.0",
                 "npm-run-all": "^4.1.5",
                 "rollup": "^2.41.4",
@@ -340,10 +341,38 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/abab": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "dev": true
+        },
         "node_modules/acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-globals": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            }
+        },
+        "node_modules/acorn-globals/node_modules/acorn": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -359,6 +388,15 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/ajv": {
@@ -419,6 +457,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
         "node_modules/array-includes": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -464,6 +508,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "dependencies": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -473,11 +535,47 @@
                 "node": ">=8"
             }
         },
+        "node_modules/async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "node_modules/aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws4": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+            "dev": true
+        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
+        },
+        "node_modules/bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "dependencies": {
+                "tweetnacl": "^0.14.3"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -500,6 +598,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
         },
         "node_modules/builtin-modules": {
             "version": "3.2.0",
@@ -534,6 +638,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "node_modules/chalk": {
             "version": "4.1.0",
@@ -575,6 +685,18 @@
             "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commondir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -596,6 +718,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -608,6 +736,55 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/cssom": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "dev": true
+        },
+        "node_modules/cssstyle": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+            "dev": true,
+            "dependencies": {
+                "cssom": "0.3.x"
+            }
+        },
+        "node_modules/dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
+            "dependencies": {
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+            "dev": true,
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "node_modules/debug": {
@@ -654,6 +831,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -676,6 +862,25 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "dependencies": {
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "node_modules/ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "node_modules/emoji-regex": {
@@ -759,6 +964,79 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dev": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=4.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/escodegen/node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/escodegen/node_modules/optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/escodegen/node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/escodegen/node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/eslint": {
@@ -1144,6 +1422,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "node_modules/extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ]
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1186,6 +1479,18 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fathom-web": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/fathom-web/-/fathom-web-3.7.3.tgz",
+            "integrity": "sha512-4kT5Y0bZXAu6mR3BnDdg2Mixdp1uejBsXCSplAw5oPEIXIf25cHUbAmHwC7oR8/vVv+Y+NnAeqrLWA6JjpKZXw==",
+            "dev": true,
+            "dependencies": {
+                "jsdom": "^11.12.0"
+            },
+            "engines": {
+                "node": ">= 7.6.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -1242,6 +1547,29 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
             "dev": true
+        },
+        "node_modules/forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -1301,6 +1629,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/glob": {
@@ -1385,6 +1722,29 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
+        "node_modules/har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/har-validator": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+            "deprecated": "this library is no longer supported",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1432,6 +1792,42 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
             "dev": true
+        },
+        "node_modules/html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-encoding": "^1.0.1"
+            }
+        },
+        "node_modules/http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.8",
+                "npm": ">=1.3.7"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/ignore": {
             "version": "4.0.6",
@@ -1679,6 +2075,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1689,6 +2091,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "node_modules/isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
         "node_modules/js-tokens": {
@@ -1710,10 +2118,68 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "node_modules/jsdom": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "dev": true,
+            "dependencies": {
+                "abab": "^2.0.0",
+                "acorn": "^5.5.3",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": "^1.0.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.9.1",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.3.0",
+                "nwsapi": "^2.0.7",
+                "parse5": "4.0.0",
+                "pn": "^1.1.0",
+                "request": "^2.87.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.4",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^5.2.0",
+                "xml-name-validator": "^3.0.0"
+            }
+        },
+        "node_modules/jsdom/node_modules/acorn": {
+            "version": "5.7.4",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+            "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "node_modules/json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
         "node_modules/json-schema-traverse": {
@@ -1726,6 +2192,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
         "node_modules/json5": {
@@ -1748,6 +2220,28 @@
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "node_modules/jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "node_modules/left-pad": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "deprecated": "use String.prototype.padStart()",
+            "dev": true
         },
         "node_modules/levn": {
             "version": "0.4.1",
@@ -1794,6 +2288,12 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "node_modules/lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
         "node_modules/lru-cache": {
@@ -1882,6 +2382,27 @@
             },
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+            "dev": true,
+            "dependencies": {
+                "mime-db": "1.47.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/minimatch": {
@@ -2095,6 +2616,21 @@
                 "which": "bin/which"
             }
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
+        },
+        "node_modules/oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
@@ -2233,6 +2769,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
         "node_modules/path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2274,6 +2816,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.2.2",
@@ -2320,6 +2868,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2338,6 +2892,12 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
+        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2345,6 +2905,15 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
             }
         },
         "node_modules/queue-microtask": {
@@ -2486,6 +3055,80 @@
                 "url": "https://github.com/sponsors/mysticatea"
             }
         },
+        "node_modules/request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+            "dev": true,
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.19"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
+            }
+        },
+        "node_modules/request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+            "dev": true,
+            "dependencies": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=0.12.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
+            }
+        },
+        "node_modules/request/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2624,6 +3267,38 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
         "node_modules/semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2692,6 +3367,16 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/sourcemap-codec": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -2735,6 +3420,40 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
+        },
+        "node_modules/sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/string-width": {
             "version": "4.2.2",
@@ -2838,6 +3557,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "node_modules/table": {
             "version": "6.0.7",
             "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
@@ -2910,6 +3635,28 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "dependencies": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -2921,6 +3668,24 @@
                 "minimist": "^1.2.0",
                 "strip-bom": "^3.0.0"
             }
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -3003,6 +3768,61 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "node_modules/verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "node_modules/w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "dependencies": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "dependencies": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "dev": true,
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3047,6 +3867,21 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "node_modules/ws": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "dev": true,
+            "dependencies": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "node_modules/yallist": {
@@ -3312,11 +4147,35 @@
                 "@types/node": "*"
             }
         },
+        "abab": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "dev": true
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true
+        },
+        "acorn-globals": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+                    "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+                    "dev": true
+                }
+            }
         },
         "acorn-jsx": {
             "version": "5.3.1",
@@ -3324,6 +4183,12 @@
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
             "dev": true,
             "requires": {}
+        },
+        "acorn-walk": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+            "dev": true
         },
         "ajv": {
             "version": "6.12.6",
@@ -3367,6 +4232,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
         "array-includes": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -3397,10 +4268,49 @@
                 "es-abstract": "^1.18.0-next.1"
             }
         },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
         "astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
         "balanced-match": {
@@ -3408,6 +4318,15 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -3427,6 +4346,12 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
         },
         "builtin-modules": {
             "version": "3.2.0",
@@ -3448,6 +4373,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
         "chalk": {
@@ -3481,6 +4412,15 @@
             "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "commondir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3499,6 +4439,12 @@
             "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
             "dev": true
         },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3508,6 +4454,54 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
+            }
+        },
+        "cssom": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.x"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            },
+            "dependencies": {
+                "whatwg-url": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
+                }
             }
         },
         "debug": {
@@ -3540,6 +4534,12 @@
                 "object-keys": "^1.0.12"
             }
         },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
         "dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3556,6 +4556,25 @@
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
+            }
+        },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "emoji-regex": {
@@ -3622,6 +4641,60 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
+        },
+        "escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "levn": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2"
+                    }
+                },
+                "optionator": {
+                    "version": "0.8.3",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+                    "dev": true,
+                    "requires": {
+                        "deep-is": "~0.1.3",
+                        "fast-levenshtein": "~2.0.6",
+                        "levn": "~0.3.0",
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2",
+                        "word-wrap": "~1.2.3"
+                    }
+                },
+                "prelude-ls": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                    "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                    "dev": true
+                },
+                "type-check": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                    "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "~1.1.2"
+                    }
+                }
+            }
         },
         "eslint": {
             "version": "7.23.0",
@@ -3928,6 +5001,18 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3967,6 +5052,15 @@
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "fathom-web": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/fathom-web/-/fathom-web-3.7.3.tgz",
+            "integrity": "sha512-4kT5Y0bZXAu6mR3BnDdg2Mixdp1uejBsXCSplAw5oPEIXIf25cHUbAmHwC7oR8/vVv+Y+NnAeqrLWA6JjpKZXw==",
+            "dev": true,
+            "requires": {
+                "jsdom": "^11.12.0"
             }
         },
         "file-entry-cache": {
@@ -4011,6 +5105,23 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
             "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
         },
         "fs-extra": {
             "version": "8.1.0",
@@ -4057,6 +5168,15 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -4119,6 +5239,22 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
+            }
+        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4151,6 +5287,35 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
             "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.1"
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
         },
         "ignore": {
             "version": "4.0.6",
@@ -4317,6 +5482,12 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4327,6 +5498,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
         "js-tokens": {
@@ -4345,10 +5522,64 @@
                 "esprima": "^4.0.0"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsdom": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "acorn": "^5.5.3",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": "^1.0.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.9.1",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.3.0",
+                "nwsapi": "^2.0.7",
+                "parse5": "4.0.0",
+                "pn": "^1.1.0",
+                "request": "^2.87.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.4",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^5.2.0",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+                    "dev": true
+                }
+            }
+        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
         "json-schema-traverse": {
@@ -4361,6 +5592,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
         "json5": {
@@ -4380,6 +5617,24 @@
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "left-pad": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
         },
         "levn": {
             "version": "0.4.1",
@@ -4417,6 +5672,12 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
         "lru-cache": {
@@ -4481,6 +5742,21 @@
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
             "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
             "dev": true
+        },
+        "mime-db": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.47.0"
+            }
         },
         "minimatch": {
             "version": "3.0.4",
@@ -4653,6 +5929,18 @@
                 }
             }
         },
+        "nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
         "object-inspect": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
@@ -4755,6 +6043,12 @@
                 "json-parse-better-errors": "^1.0.1"
             }
         },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4785,6 +6079,12 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -4812,6 +6112,12 @@
                 "find-up": "^2.1.0"
             }
         },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4824,10 +6130,22 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
         "queue-microtask": {
@@ -4929,6 +6247,62 @@
             "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
+                }
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5021,6 +6395,24 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
         "semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5068,6 +6460,13 @@
                 "is-fullwidth-code-point": "^3.0.0"
             }
         },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "optional": true
+        },
         "sourcemap-codec": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -5110,6 +6509,29 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
         "string-width": {
@@ -5184,6 +6606,12 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "table": {
             "version": "6.0.7",
             "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
@@ -5244,6 +6672,25 @@
                 "is-number": "^7.0.0"
             }
         },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
         "tsconfig-paths": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -5255,6 +6702,21 @@
                 "minimist": "^1.2.0",
                 "strip-bom": "^3.0.0"
             }
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -5319,6 +6781,58 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5351,6 +6865,21 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "ws": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^8.1.0",
         "eslint-plugin-node": "^11.1.0",
+        "fathom-web": "^3.7.3",
         "globby": "^11.0.0",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.41.4",

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -8,68 +8,18 @@
  * - rerun fathom on mutation observer?
  * - keep track of viewTime of classified elements using intersection observer?
  * - memoizations
- * - 
  * - fallbacks?
+ * - add documentation
+ *
+ *
  * - draw borders as an option
+ * - implement results sending
  */
 
 import {ruleset, type} from "fathom-web";
 
-let traineesAdded = false;
-
-// Add user rulesets to the window global
-function addTrainees(trainees, runFathom = true) {
-    for (const [name, rules] of trainees) {
-        window.webScience.fathom.trainees.set(name, rules);
-    }
-    traineesAdded = true;
-}
-
-
-function runTrainee(ruleName, results, color = "red") { 
-    const trainees = window.webScience.fathom.trainees;
-    const trainee = trainees.get(ruleName);
-    const facts = trainee.rulesetMaker().against(document);
-    facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // check bias code
-
-    // Run the ruleset
-    const allNodes = facts.get(type(ruleName)); 
-
-    // For all candidate nodes, observe/borderize those with high scores
-    for (const fnode of allNodes) {
-        let score = fnode.scoreFor(ruleName);
-        // TODO: Allow configuration of confidence threshold
-        if (score >= 0.5) {
-            fnode.element.style.border = "5px solid " + color;
-            console.log("*** Found " + ruleName + " node ***\n" +
-                        "Confidence: " + score.toString(10));
-			fnode.element.dataset.totalViewTime = 0;
-			fnode.element.dataset.lastViewStarted = 0;
-
-            results.set(fnode.element, {
-                "score": score,
-                "type": ruleName,
-                "fnode": fnode,
-                "vector": fnode._types.get(ruleName).score,
-                "clicked": false,
-            });
-        }
-    }
-
-    console.log("Finished ruleset " + ruleName);
-}
-
-function runAllTrainees() {
-    const trainees = window.webScience.fathom.trainees;
-    let results = new Map();
-    for (const [ruleName, rules] of trainees) {
-        runTrainee(ruleName, results)
-    }
-    return results;
-}
-
-
 (function() {
+
     // Check if content script is already running
     if ("webScience" in window) {
         if ("fathom" in window.webScience) {
@@ -97,15 +47,29 @@ function runAllTrainees() {
      */
     let pageClassified = false;
 
+    // Fathom cannot be started before trainees are added by user
+    let traineesAdded = false;
 
-    // Function to call once pageManager is loaded
-    function pageManagerLoaded() {
-        console.log("pageManager loaded, running fathom content script");
+    // Fathom cannot be started before pageManager is loaded
+    let pageManagerLoaded = false;
+
+
+    // Function to initalize fathom once conditions are fulfilled 
+    function fathomInit() {
+
+        // Sanity check
+        if (!pageManagerLoaded || !traineesAdded) {
+            console.log("fathomInit called before conditions are fulfilled");
+            return;
+        }
+
+        console.log("Initializing fathom");
         const pageManager = window.webScience.pageManager;
 
         // Listen for messages from background script
         // Background script will tell us if this page should be classified
         // and what Fathom rulesets to use
+        // TODO: Is it possible to miss these messages due to race conditions?
         browser.runtime.onMessage.addListener((message) => {
 
             // Don't do anything if isClassifiable == false
@@ -119,40 +83,93 @@ function runAllTrainees() {
                 console.log("Page already classified, returning");
                 return;
             }
+            
+            // Set to true before the run to avoid parallel runs
+            pageClassified = true;
 
-            // Run fathom, but wait until trainees are added
-            function runFathom() {
-                if (!traineesAdded) {
-                    console.log("trainees not yet added");
-                    setTimeout(runFathom, 200);
-                }
-                else {
-                    // Set to true before we run to avoid parallel runs
-                    pageClassified = true;
+            console.log("Running fathom");
 
-                    console.log("Running fathom");
+            // run Fathom here
+            let results = runAllTrainees(message.trainees);
 
-                    // run Fathom here
-                    let results = runAllTrainees(message.trainees);
-
-                    // Send results to background script
-                    console.log("Sending fathom results");
-                    console.log(results);
-                    pageManager.sendMessage({
-                        type: "webScience.fathom.fathomData",
-                        test: "hello from content script",
-                        results: results
-                    });
-                    console.log("Fathom results sent");
-                }
-            }
-            runFathom();
+            // Send results to background script
+            console.log("Sending fathom results");
+            console.log(results);
+            pageManager.sendMessage({
+                type: "webScience.fathom.fathomData",
+                results: results
+            });
+            console.log("Fathom results sent");
         });
     }
 
-    // If pageManager is loaded, call our main function
+    // Handle race conditions 
+    // Flags are only set to true through this function
+    // When trainees are added or pageManager is loaded, set the flag to true
+    // If all flags are set to true then initialize fathom
+    function fathomInitWrapper(traineesAddedIn, pageManagerLoadedIn) {
+        traineesAdded = traineesAddedIn;
+        pageManagerLoaded = pageManagerLoadedIn;
+        if (traineesAdded && pageManagerLoaded) {
+            fathomInit();
+        }
+    }
+
+    // Add user rulesets to the window global
+    function addTrainees(trainees, runFathom = true) {
+        for (const [name, rules] of trainees) {
+            window.webScience.fathom.trainees.set(name, rules);
+        }
+        fathomInitWrapper(true, pageManagerLoaded);
+    }
+
+    // Run a specific ruleset from the window global
+    function runTrainee(ruleName, results, color = "red") { 
+        const trainees = window.webScience.fathom.trainees;
+        const trainee = trainees.get(ruleName);
+        const facts = trainee.rulesetMaker().against(document);
+        facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // check bias code
+
+        // Run the ruleset
+        const allNodes = facts.get(type(ruleName)); 
+
+        // For all candidate nodes, observe/borderize those with high scores
+        for (const fnode of allNodes) {
+            let score = fnode.scoreFor(ruleName);
+            // TODO: Allow configuration of confidence threshold
+            if (score >= 0.5) {
+                fnode.element.style.border = "5px solid " + color;
+                console.log("*** Found " + ruleName + " node ***\n" +
+                            "Confidence: " + score.toString(10));
+                fnode.element.dataset.totalViewTime = 0;
+                fnode.element.dataset.lastViewStarted = 0;
+
+                results.set(fnode.element, {
+                    "score": score,
+                    "type": ruleName,
+                    "fnode": fnode,
+                    "vector": fnode._types.get(ruleName).score,
+                    "clicked": false,
+                });
+            }
+        }
+
+        console.log("Finished ruleset " + ruleName);
+    }
+
+    // Run all rulesets in the window global
+    function runAllTrainees() {
+        const trainees = window.webScience.fathom.trainees;
+        let results = new Map();
+        for (const [ruleName, rules] of trainees) {
+            runTrainee(ruleName, results)
+        }
+        return results;
+    }
+
+    // If pageManager is loaded, set the flag as true
     if ("webScience" in window && "pageManager" in window.webScience) {
-        pageManagerLoaded();
+        fathomInitWrapper(traineesAdded, true);
     }
 
     // If pageManager is not loaded, push our main function to queue
@@ -160,7 +177,7 @@ function runAllTrainees() {
         if (!("pageManagerHasLoaded" in window)) {
             window.pageManagerHasLoaded = [];
         }
-        window.pageManagerHasLoaded.push(pageManagerLoaded());
+        window.pageManagerHasLoaded.push(fathomInitWrapper(traineesAdded, true));
     }
 
     console.log("content script initialized");

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -3,11 +3,14 @@
  * to classify the DOM elements of a page.
  * @module webScience.fathom.content
  *
- * TODO: 
+ * TODO:
+ * High priority:
  * - rerun fathom on mutation observer?
  * - keep track of viewTime of classified elements using intersection observer?
- * - draw borders as an option?
  * - memoizations
+ * - 
+ * - fallbacks?
+ * - draw borders as an option
  */
 
 import {ruleset, type} from "fathom-web";
@@ -27,7 +30,7 @@ function runTrainee(ruleName, results, color = "red") {
     const trainees = window.webScience.fathom.trainees;
     const trainee = trainees.get(ruleName);
     const facts = trainee.rulesetMaker().against(document);
-    facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // bias not working properly
+    facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // check bias code
 
     // Run the ruleset
     const allNodes = facts.get(type(ruleName)); 
@@ -35,6 +38,7 @@ function runTrainee(ruleName, results, color = "red") {
     // For all candidate nodes, observe/borderize those with high scores
     for (const fnode of allNodes) {
         let score = fnode.scoreFor(ruleName);
+        // TODO: Allow configuration of confidence threshold
         if (score >= 0.5) {
             fnode.element.style.border = "5px solid " + color;
             console.log("*** Found " + ruleName + " node ***\n" +

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -145,7 +145,7 @@ import {ruleset, type} from "fathom-web";
                     "type": ruleName,
                     // "fnode": fnode,
                     "vector": fnode._types.get(ruleName).score,
-                    "clicked": false,
+                    // "clicked": false,
                 });
             }
         }

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -7,7 +7,55 @@
  * - rerun fathom on mutation observer?
  * - keep track of viewTime of classified elements using intersection observer?
  * - draw borders as an option?
+ * - memoizations
  */
+
+import {ruleset, type} from "fathom-web";
+
+
+function runTrainee(trainees, ruleName, color = "red", results) {
+    let trainee = trainees[ruleName];
+    let rulesetMaker = Function('"use strict";return (' + trainee.rulesetMaker + ')')();
+
+    let rules = rulesetMaker().rules();
+    let coeffs = trainees.get(ruleName).coeffs;
+    let bias = [[rulenName, trainees.get(ruleName).bias]];
+    let finalRuleset = ruleset(rules, coeffs, bias);
+
+    // Run the ruleset
+    const facts = finalRuleset.against(document);
+    const allNodes = facts.get(type(ruleName)); 
+
+    // For all candidate nodes, observe/borderize those with high scores
+    for (fnode of allNodes) {
+        let score = fnode.scoreFor(ruleName);
+        if (score >= 0.5) {
+            fnode.element.style.border = "5px solid " + color;
+            console.log("*** Found " + ruleName + " node ***\n" +
+                        "Confidence: " + score.toString(10));
+			fnode.element.dataset.totalViewTime = 0;
+			fnode.element.dataset.lastViewStarted = 0;
+
+            results.set(fnode.element, {
+                "score": score,
+                "type": ruleName,
+                "fnode": fnode,
+                "vector": fnode._types.get(ruleName).score,
+                "clicked": false,
+            });
+        }
+    }
+
+    console.log("Finished ruleset " + ruleName);
+}
+
+function runAllTrainees(trainees) {
+    let results = new Map();
+    for (const ruleName in trainees) {
+        runTrainee(trainees, ruleName, results)
+    }
+    return results;
+}
 
 
 (function() {
@@ -30,6 +78,7 @@
      * @type {boolean}
      */
     let pageClassified = false;
+
     
     // Function to call once pageManager is loaded
     function pageManagerLoaded() {
@@ -51,14 +100,20 @@
             }
 
             console.log("Running fathom");
-            // run Fathom here
+
+            // Set to true before we run to avoid parallel runs
             pageClassified = true;
+
+            // run Fathom here
+            results = runAllTrainees(message.trainees);
 
             // Send results to background script
             console.log("Sending fathom results");
+            console.log(results);
             pageManager.sendMessage({
                 type: "webScience.fathom.fathomData",
-                test: "hello from content script"
+                test: "hello from content script",
+                results: results
             });
             console.log("Fathom results sent");
         });

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -12,10 +12,12 @@
 
 import {ruleset, type} from "fathom-web";
 
+// TODO: change trainee to a Map
+
 // Add user rulesets to the window global
 function addTrainees(trainees) {
     for (const [name, rules] of trainees) {
-        window.webScience.fathom.trainees[name] = rules;
+        window.webScience.fathom.trainees.set(name, rules);
     }
 }
 
@@ -23,17 +25,22 @@ function addTrainees(trainees) {
 function runTrainee(ruleName, results, color = "red") { 
     const trainees = window.webScience.fathom.trainees;
 
-    let rules = trainees[ruleName].rulesetMaker().rules();
-    let coeffs = trainees[ruleName].coeffs;
-    let bias = [[ruleName, trainees[ruleName].bias]];
-    let finalRuleset = ruleset(rules, coeffs, bias);
+    // let rules = trainees.get(ruleName).rulesetMaker().rules();
+    // let coeffs = trainees.get(ruleName).coeffs;
+    // let bias = [[ruleName, trainees.get(ruleName).bias]];
+    // let finalRuleset = ruleset(rules, coeffs, bias);
+
+    const trainee = trainees.get(ruleName);
+    const facts = trainee.rulesetMaker().against(document);
+    facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // bias not working properly
+
 
     // Run the ruleset
-    const facts = finalRuleset.against(document);
+    // const facts = finalRuleset.against(document);
     const allNodes = facts.get(type(ruleName)); 
 
     // For all candidate nodes, observe/borderize those with high scores
-    for (fnode of allNodes) {
+    for (const fnode of allNodes) {
         let score = fnode.scoreFor(ruleName);
         if (score >= 0.5) {
             fnode.element.style.border = "5px solid " + color;
@@ -58,9 +65,9 @@ function runTrainee(ruleName, results, color = "red") {
 function runAllTrainees() {
     const trainees = window.webScience.fathom.trainees;
     let results = new Map();
-    for (const ruleName in trainees) {
+    for (const [ruleName, rules] of trainees) {
         runTrainee(ruleName, results)
-        break;//TODO:remove
+        // break;//TODO:remove
     }
     return results;
 }
@@ -74,7 +81,7 @@ function runAllTrainees() {
         }
         else {
             window.webScience.fathom = {
-                trainees: {},
+                trainees: new Map(),
                 addTrainees: addTrainees,
             }
         }
@@ -83,7 +90,7 @@ function runAllTrainees() {
         // Else, this is the first webScience initialization
         window.webScience = {};
         window.webScience.fathom = {
-            trainees: {},
+            trainees: new Map(),
             addTrainees: addTrainees,
         }
     }

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -39,7 +39,7 @@ import {ruleset, type} from "fathom-web";
         }
     }
 
-    //Whether the elements of this page have been classified.
+    // Whether the elements of this page have been classified.
     let pageClassified = false;
 
     // Fathom cannot be started before trainees are added by user
@@ -52,7 +52,7 @@ import {ruleset, type} from "fathom-web";
     // Function to initalize fathom once conditions are fulfilled 
     function fathomInit() {
 
-        // Sanity check
+        // Sanity check for the conditions
         if (!pageManagerLoaded || !traineesAdded) {
             console.log("fathomInit called before conditions are fulfilled");
             return;
@@ -84,25 +84,22 @@ import {ruleset, type} from "fathom-web";
 
             console.log("Running fathom");
 
-            // run Fathom here
+            // Run all Fathom rulesets
             let results = runAllTrainees(message.trainees);
 
             // Send results to background script
             console.log("Sending fathom results");
-            console.log(results);
-            let resultsObj = Object.fromEntries(results);
             pageManager.sendMessage({
                 type: "webScience.fathom.fathomData",
-                results: resultsObj
+                results: Object.fromEntries(results)
             });
             console.log("Fathom results sent");
         });
     }
 
-    // Handle race conditions 
-    // Flags are only set to true through this function
+    // Handle race conditions
     // When trainees are added or pageManager is loaded, set the flag to true
-    // If all flags are set to true then initialize fathom
+    // If all flags are set to true then call fathomInit
     function fathomInitWrapper(traineesAddedIn, pageManagerLoadedIn) {
         traineesAdded = traineesAddedIn;
         pageManagerLoaded = pageManagerLoadedIn;
@@ -121,15 +118,15 @@ import {ruleset, type} from "fathom-web";
 
     // Run a specific ruleset from the window global
     function runTrainee(ruleName, results, color = null) { 
+
+        // Set up Fathom and run the rule
         const trainees = window.webScience.fathom.trainees;
         const trainee = trainees.get(ruleName);
         const facts = trainee.rulesetMaker().against(document);
         facts.setCoeffsAndBiases(trainee.coeffs, [[ruleName, trainee.bias]]); // check bias code
-
-        // Run the ruleset
         const allNodes = facts.get(type(ruleName)); 
 
-        // For all candidate nodes, observe/borderize those with high scores
+        // For all candidate nodes, borderize those with high scores
         for (const fnode of allNodes) {
             let score = fnode.scoreFor(ruleName);
             // TODO: Allow configuration of confidence threshold
@@ -137,8 +134,8 @@ import {ruleset, type} from "fathom-web";
 
                 // Borderize if any colors are specified
                 if (color !== null) {
-					fnode.element.style.border = "5px solid " + color;
-					console.log("Found " + ruleName + " node " + 
+                    fnode.element.style.border = "5px solid " + color;
+                    console.log("Found " + ruleName + " node " + 
                                 "(confidence: " + score.toString(10) + ")");
                 }
 

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -2,7 +2,13 @@
  * Content script for the Fathom module. Uses Mozilla Fathom
  * to classify the DOM elements of a page.
  * @module webScience.fathom.content
+ *
+ * TODO: 
+ * - rerun fathom on mutation observer?
+ * - keep track of viewTime of classified elements using intersection observer?
+ * - draw borders as an option?
  */
+
 
 (function() {
     // Check if content script is already running
@@ -39,14 +45,22 @@
                 return;
             }
 
+            if (pageClassified) {
+                console.log("Page already classified, returning");
+                return;
+            }
+
+            console.log("Running fathom");
             // run Fathom here
             pageClassified = true;
 
             // Send results to background script
+            console.log("Sending fathom results");
             pageManager.sendMessage({
                 type: "webScience.fathom.fathomData",
                 test: "hello from content script"
             });
+            console.log("Fathom results sent");
         });
     }
 

--- a/src/content-scripts/fathom.content.js
+++ b/src/content-scripts/fathom.content.js
@@ -1,0 +1,67 @@
+/**
+ * Content script for the Fathom module. Uses Mozilla Fathom
+ * to classify the DOM elements of a page.
+ * @module webScience.fathom.content
+ */
+
+(function() {
+    // Check if content script is already running
+    if ("webScience" in window) {
+        if ("fathomActive" in window.webScience) {
+            return;
+        }
+        window.webScience.fathomActive = true;
+    }
+    else {
+        // Else, this is the first webScience initialization
+        window.webScience = {
+            fathomActive: true
+        }
+    }
+
+    /**
+     * Whether the elements of this page have been classified.
+     * @type {boolean}
+     */
+    let pageClassified = false;
+    
+    // Function to call once pageManager is loaded
+    function pageManagerLoaded() {
+        console.log("pageManager loaded, running fathom content script");
+        const pageManager = window.webScience.pageManager;
+
+        // Listen for messages from background script
+        // Background script will tell us if this page should be classified
+        // and what Fathom rulesets to use
+        browser.runtime.onMessage.addListener((message) => {
+            if (message.type !== "webScience.fathom.isClassifiable" ||
+                !message.isClassifiable) {
+                return;
+            }
+
+            // run Fathom here
+            pageClassified = true;
+
+            // Send results to background script
+            pageManager.sendMessage({
+                type: "webScience.fathom.fathomData",
+                test: "hello from content script"
+            });
+        });
+    }
+
+    // If pageManager is loaded, call our main function
+    if ("webScience" in window && "pageManager" in window.webScience) {
+        pageManagerLoaded();
+    }
+    // If pageManager is not loaded, push our main function to queue
+    else {
+        if (!("pageManagerHasLoaded" in window)) {
+            window.pageManagerHasLoaded = [];
+        }
+        window.pageManagerHasLoaded.push(pageManagerLoaded());
+    }
+
+    console.log("content script initialized");
+})();
+

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -27,6 +27,7 @@ import * as messaging from "./messaging.js";
 import * as events from "./events.js";
 import * as matching from "./matching.js";
 import * as inline from "./inline.js";
+import addTrainees from "./content-scripts/fathom.content.js";
 import fathomContentScript from "./content-scripts/fathom.content.js";
 
 export function test() {
@@ -107,7 +108,7 @@ let initialized = false;
  * @param {Object} options - Options for the listener.
  * @param {string[] options.matchPatterns} matchPatterns - The match patterns 
  * for pages where the listener should be notified.
- * @param {fathom.Trainees} trainees - The trainees for this listener.
+ * @param {fathom.Trainees} trainees - The trainees for this listener, a Map.
  * @private
  */
 async function addListener(listener, {matchPatterns, trainees}) {
@@ -133,7 +134,6 @@ async function addListener(listener, {matchPatterns, trainees}) {
         // Message to send to content script if this page should be classified
         messaging.registerSchema("webScience.fathom.isClassifiable", {
             isClassifiable: "boolean",
-            trainees: "object"
         })
 
         // When a tab is updated, send it a message if the page should be 
@@ -155,12 +155,13 @@ async function addListener(listener, {matchPatterns, trainees}) {
                         }
                     }
                 }
-                messaging.sendMessageToTab(tabId, {
-                    type: "webScience.fathom.isClassifiable",
-                    // isClassifiable: classifiable,
-                    isClassifiable: true,
-                    trainees: traineesSet
-                })
+                function sendIsClassifiable() {
+                    messaging.sendMessageToTab(tabId, {
+                        type: "webScience.fathom.isClassifiable",
+                        isClassifiable: classifiable,
+                    });
+                }
+                setTimeout(sendIsClassifiable, 3000); //TODO: remove
             }
         });
     }

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -35,8 +35,11 @@ import fathomContentScript from "./content-scripts/fathom.content.js";
 /**
  * Fathom classification results sent by the content script.
  * @typedef {Object} FathomDataObject
- * @property {number} pageId - The ID for the page, unique across browsing sessions.
- * @property {string} url - The URL of the page, without any hash.
+ *
+ * TODO: Finalize data schema
+ * Likely would involve the URL, pageID, and the fathom classification results.
+ * Currently, just sends an object containing every element with greater than
+ * 0.5 confidence score (key), along with their feature vector and actual score (value).
  */
 
 /**

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -30,22 +30,7 @@ import * as messaging from "./messaging.js";
 import * as events from "./events.js";
 import * as matching from "./matching.js";
 import * as inline from "./inline.js";
-import addTrainees from "./content-scripts/fathom.content.js";
 import fathomContentScript from "./content-scripts/fathom.content.js";
-
-export function test() {
-    const rules = ruleset([
-		// Look at all divs
-		rule(dom('div'), type('test')),
-        // Score based on visibility
-		rule(type('test'), score(isVisible), {name: 'visible'}),
-        // Output max score
-		rule(type('test').max(), out('test'))
-    ])
-
-    console.log("Fathom module test message.");
-}
-
 
 /**
  * Fathom classification results sent by the content script.
@@ -111,7 +96,7 @@ async function addListener(listener, {matchPatterns}) {
         // Initialize pageManager
         await pageManager.initialize();
         
-        // Listen for Fathom classification messages
+        // Listen for Fathom classification results, sent by content script
         // This messageListener receives a fathomDataObject from a content script.
         messaging.onMessage.addListener(messageListener,
             {
@@ -141,14 +126,10 @@ async function addListener(listener, {matchPatterns}) {
                     }
                 }
 
-                function sendIsClassifiable() {
-                    messaging.sendMessageToTab(tabId, {
-                        type: "webScience.fathom.isClassifiable",
-                        isClassifiable: classifiable,
-                    });
-                }
-                // setTimeout(sendIsClassifiable, 100); //TODO: remove
-                sendIsClassifiable();
+                messaging.sendMessageToTab(tabId, {
+                    type: "webScience.fathom.isClassifiable",
+                    isClassifiable: classifiable,
+                });
             }
         });
     }

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -141,27 +141,22 @@ async function addListener(listener, {matchPatterns, trainees}) {
         browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
             if ("url" in tab) {
                 classifiable = false;
-                traineesSet = {}
+                // Iterate over listenerRecords, check if this url matches any
                 for (const listenerRecord of fathomDataListeners.values()) {
                     if (listenerRecord.matchPatternSet.matches(tab.url)) {
-                        // Get all the relevant trainees, merge to traineesSet
-                        for (const trainee of listenerRecord.trainees.keys()) {
-                            if (trainee in traineesSet) {
-                                console.warn("Duplicate trainees found: " + trainee);
-                            }
-                            traineesSet[trainee] = listenerRecord.trainees.get(trainee);
-                            // traineesSet[trainee].rulesetMaker = traineesSet[trainee].rulesetMaker.toString();
-                            classifiable = true;
-                        }
+                        classifiable = true;
+                        break;
                     }
                 }
+
                 function sendIsClassifiable() {
                     messaging.sendMessageToTab(tabId, {
                         type: "webScience.fathom.isClassifiable",
                         isClassifiable: classifiable,
                     });
                 }
-                setTimeout(sendIsClassifiable, 3000); //TODO: remove
+                // setTimeout(sendIsClassifiable, 100); //TODO: remove
+                sendIsClassifiable();
             }
         });
     }

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -102,7 +102,6 @@ async function addListener(listener, {matchPatterns}) {
             {
                 type: "webScience.fathom.fathomData",
                 schema: {
-                    test: "string",
                     results: "object"
                 }
             }

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -1,0 +1,214 @@
+/**
+ * This module enables machine learning classification of DOM elements using
+ * Mozilla Fathom.
+ *
+ * A client will call addListener on the webScience.fathom.onFathomData event, specifiying
+ * their callback, trainees, and matchPatterns (specifying which URLs to run fathom on).
+ * This background script then stores this information in a Map, with the key being the client's
+ * callback, and the value being the client's preferences.
+ *
+ * When a page is opened, the background script will determine which trainees to use
+ * and if the page matches the matchPattern. A message will then be
+ * sent to the content script containing the relevant trainees. The content script will
+ * then run Fathom to classify elements in the page.
+ *
+ * Once the content script is done with classification, it will send a message
+ * to the background script, which contains the results. These messages are
+ * then processed using the client's callbacks.
+ *
+ * @module webScience.fathom
+ */
+
+import {ruleset, rule, dom, type, score, out, utils} from 'fathom-web';
+const {isVisible, linearScale} = utils;
+
+import * as pageManager from "./pageManager.js";
+import * as messaging from "./messaging.js";
+import * as events from "./events.js";
+import * as matching from "./matching.js";
+import * as inline from "./inline.js";
+import fathomContentScript from "./content-scripts/fathom.content.js";
+
+export function test() {
+    const rules = ruleset([
+		// Look at all divs
+		rule(dom('div'), type('test')),
+        // Score based on visibility
+		rule(type('test'), score(isVisible), {name: 'visible'}),
+        // Output max score
+		rule(type('test').max(), out('test'))
+    ])
+
+    console.log("Fathom module test message.");
+}
+
+/**
+ * @typedef {Object} Trainees
+ * https://mozilla.github.io/fathom/example.html?highlight=trainees
+ * 
+ * The Trainees object is a set of rules for the Fathom trainer. This object
+ * contains coefficients, bias, viewportSize, and the set of rules (which
+ * specifies which DOM elements to process, and how to calculate scores) that
+ * will be applied to the page. 
+ */
+
+/**
+ * Fathom classification results sent by the content script.
+ * @typedef {Object} FathomDataObject
+ * @property {number} pageId - The ID for the page, unique across browsing sessions.
+ * @property {string} url - The URL of the page, without any hash.
+ */
+
+/**
+ * The listener specified by the client.
+ * @callback fathomDataListener
+ * @param {FathomDataObject} Results of the Fathom classification on a page.
+ */
+
+/**
+ * @typedef {Object} FathomDataListenerRecord
+ * @property {matching.MatchPatternSet} matchPatternSet - The match patterns for the listener.
+ * @property {Trainees} trainees - The trainees (rulesets) for this listener
+ * @property {browser.contentScripts.RegisteredContentScript} contentScript - The content
+ * script associated with the listener.
+ */
+
+/**
+ * A map where the key is a listener function and each value is a record for that listener function.
+ * @constant {Map<fathomDataListener, FathomDataListenerRecord>}
+ * @private
+ */
+const fathomDataListeners = new Map();
+
+/**
+ * An event that fires when a page's contents has been successfully classified
+ * through a Fathom content script. 
+ *
+ * @constant onFathomData
+ */
+export const onFathomData = events.createEvent({
+    name: "webScience.fathom.onFathomData",
+    addListenerCallback: addListener,
+    removeListenerCallback: removeListener,
+    notifyListenersCallback: () => { return false; }
+});
+
+/**
+ * Whether the module has completed initialization.
+ * @type{boolean}
+ * @private
+ */
+let initialized = false;
+
+
+/**
+ * A callback function to add a fathomDataListener.
+ * @param {fathomDataCallback} listener - The listener that is being removed.
+ * @param {Object} options - Options for the listener.
+ * @param {string[] options.matchPatterns} matchPatterns - The match patterns 
+ * for pages where the listener should be notified.
+ * @param {fathom.Trainees} trainees - The trainees for this listener.
+ * @private
+ */
+async function addListener(listener, {matchPatterns, trainees}) {
+    // Initialize the listener
+    if (!initialized) {
+        initialized = true;
+
+        // Initialize pageManager
+        await pageManager.initialize();
+        
+        // Listen for Fathom classification messages
+        // This messageListener receives a fathomDataObject from a content script.
+        messaging.onMessage.addListener(messageListener,
+            {
+                type: "webScience.fathom.fathomData",
+                schema: {
+                    test: "string",
+                }
+            }
+        );
+        
+        // Message to send to content script if this page should be classified
+        messaging.registerSchema("webScience.fathom.isClassifiable", {
+            isClassifiable: "boolean",
+            trainees: "object"
+        })
+
+        // TODO: is onUpdated correct?
+        browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+            if ("url" in tab) {
+                classifiable = false;
+                traineesSet = {};
+                for (const listenerRecord of fathomDataListeners.values()) {
+                    if (listenerRecord.matchPatternSet.matches(tab.url)) {
+                        // Get all the relevant trainees, merge to traineesSet
+                        for (const trainee in listenerRecord.trainees) {
+                            if (trainee in traineesSet) {
+                                console.warn("Duplicate trainees found: " + trainee);
+                            }
+                            traineesSet[trainee] = listenerRecord.trainees[trainee];
+                            classifiable = true;
+                        }
+                    }
+                }
+                messaging.sendMessageToTab(tabId, {
+                    type: "webScience.fathom.isClassifiable",
+                    isClassifiable: classifiable,
+                    trainees: traineesSet
+                })
+            }
+        });
+    }
+
+    // Register content script for the listener
+    const contentScript = await browser.contentScripts.register({
+        matches: matchPatterns,
+        js: [{
+            code: inline.dataUrlToString(fathomContentScript)
+        }],
+        runAt: "document_idle"
+    })
+
+    // Compile the match patterns for the listener
+    const matchPatternSet = matching.createMatchPatternSet(matchPatterns);
+
+    // Add listener to fathomDataListeners map
+    fathomDataListeners.set(listener, {
+        matchPatternSet,
+        trainees,
+        contentScript
+    });
+}
+
+
+/**
+ * A callback function to remove a fathomDataListener.
+ * @param {fathomDataCallback} listener - The listener that is being removed.
+ * @private
+ */
+function removeListener(listener) {
+    const listenerRecord = fathomDataListeners.get(listener);
+    if (listenerRecord === undefined) {
+        return;
+    }
+    listenerRecord.contentScript.unregister();
+    fathomDataListeners.delete(listener);
+}
+
+/**
+ * A callback function to handle messages from the content script.
+ * @param {FathomDataObject} fathomDataObject - Fathom classification results.
+ * @private
+ */
+function messageListener(fathomDataObject) {
+    console.log("messageListener called");
+    for (const [listener, listenerRecord] of fathomDataListeners) {
+        listener(fathomDataObject);
+
+        // Notify listener if the url matches the listener's matchPatterns
+        if (listenerRecord.matchPatternSet.matches(fathomDataObject.url)) {
+            listener(fathomDataObject);
+        }
+    }
+}

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -114,17 +114,18 @@ async function addListener(listener, {matchPatterns}) {
 
         // When a tab is updated, send it a message if the page should be 
         // classified with Fathom
+        // TODO: onUpdated may not be the right event
         browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
             if ("url" in tab) {
-                classifiable = false;
                 // Iterate over listenerRecords, check if this url matches any
+                classifiable = false;
                 for (const listenerRecord of fathomDataListeners.values()) {
                     if (listenerRecord.matchPatternSet.matches(tab.url)) {
                         classifiable = true;
                         break;
                     }
                 }
-
+                // Send the message to content script
                 messaging.sendMessageToTab(tabId, {
                     type: "webScience.fathom.isClassifiable",
                     isClassifiable: classifiable,

--- a/src/fathom.js
+++ b/src/fathom.js
@@ -125,6 +125,7 @@ async function addListener(listener, {matchPatterns, trainees}) {
                 type: "webScience.fathom.fathomData",
                 schema: {
                     test: "string",
+                    results: "object"
                 }
             }
         );
@@ -135,26 +136,29 @@ async function addListener(listener, {matchPatterns, trainees}) {
             trainees: "object"
         })
 
-        // TODO: is onUpdated correct?
+        // When a tab is updated, send it a message if the page should be 
+        // classified with Fathom
         browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
             if ("url" in tab) {
                 classifiable = false;
-                traineesSet = {};
+                traineesSet = {}
                 for (const listenerRecord of fathomDataListeners.values()) {
                     if (listenerRecord.matchPatternSet.matches(tab.url)) {
                         // Get all the relevant trainees, merge to traineesSet
-                        for (const trainee in listenerRecord.trainees) {
+                        for (const trainee of listenerRecord.trainees.keys()) {
                             if (trainee in traineesSet) {
                                 console.warn("Duplicate trainees found: " + trainee);
                             }
-                            traineesSet[trainee] = listenerRecord.trainees[trainee];
+                            traineesSet[trainee] = listenerRecord.trainees.get(trainee);
+                            // traineesSet[trainee].rulesetMaker = traineesSet[trainee].rulesetMaker.toString();
                             classifiable = true;
                         }
                     }
                 }
                 messaging.sendMessageToTab(tabId, {
                     type: "webScience.fathom.isClassifiable",
-                    isClassifiable: classifiable,
+                    // isClassifiable: classifiable,
+                    isClassifiable: true,
                     trainees: traineesSet
                 })
             }

--- a/src/webScience.js
+++ b/src/webScience.js
@@ -64,3 +64,6 @@ export { workers }
 
 import * as pageTransition from "./pageTransition.js"
 export { pageTransition }
+
+import * as fathom from "./fathom.js"
+export { fathom }


### PR DESCRIPTION
## Description 
Resolves #27. Integrates [Mozilla Fathom](https://mozilla.github.io/fathom/index.html) to enable ML classification of pages or DOM elements within a page. At the _element_ level, example applications include recognizing which DOM elements represent overlays, ads, login forms, privacy policies, and cookie banners. At the _page_ level, example applications include recognizing shopping pages, login pages, and news article pages. The user must first [train their own model](https://mozilla.github.io/fathom/training.html). This library then makes it simple to deploy the trained model through a Rally extension.

## Technical
The [fathom-web](https://www.npmjs.com/package/fathom-web) package is installed as devDependency. If the user wants to use this module, they must install this package in their own extension. The broad architecture of this module follows [pageManager](https://github.com/mozilla-rally/web-science/blob/main/src/pageManager.js) and [pageText](https://github.com/mozilla-rally/web-science/blob/main/src/pageText.js). A summary of how it works:

1. The `fathom.js` background script exports the `webScience.fathom.onFathomData` event. The user must call `webScience.fathom.onFathomData.addListener()` from their own background script, specifying their callback and URL match pattern. Fathom will only be run on URLs which match the specified pattern. 
2. The user must also call the global function  `window.webScience.fathom.addTrainees()` from their own content script to specify their trained Fathom model. 
3. When a tab is opened, the fathom background script sends an `webScience.fathom.isClassifiable` message to the content script running on the tab. This boolean is determined by the user's URL match patterns. 
4. Upon receiving an `isClassifiable == true` message, the Fathom content script will proceed to classify the page based on the user's rulesets, which were added via the global  `window.webScience.fathom.addTrainees()`.
5. Once the Fathom content script is done, results are sent to the background script as a `webScience.fathom.fathomData` message. The Fathom background script then processes the results and calls the user's callbacks on the results.

## Discussions

1. This module currently supports the most basic functionality: run Fathom at most once upon page load, then return the classification results. In reality, the element the user is looking for may be dynamically loaded at some point after the page is loaded. Should a rerunning function based on MutationObserver be implemented in the content script? This would be difficult to do on the user's end, so might be worth doing in this module.

2. Once an element is classified, should this module handle tracking the amount of time the element is in the user's screen? This should be doable on the user's end and is more study specific, but is likely to be a very commonly used feature, making it worth handling in the module. Most other types of element tracking (such as whether or not the element was clicked) are study specific and would fit better as a user implementation. This module can return the classified DOM elements, after which the user may monitor it as they see fit. 

## Todos

1. Memoize page contents to optimize running multiple Fathom rulesets.
2. Make border drawing a user configurable option.
3. Potentially change the use of `onUpdated` as the main event to trigger Fathom runs.
4. Write jsdoc comments.
5. Remove `console.log` lines, which are all temporary and only used for development purposes.
6. Define a proper classification results schema.