### PR TITLE
Standardization for system and monotonic clocks

### DIFF
--- a/src/content-scripts/pageManager.content.js
+++ b/src/content-scripts/pageManager.content.js
@@ -111,6 +111,7 @@
 
 import { generateId } from "../id.js";
 import { createEvent } from "../events.js";
+import { fromMonotonicClock } from "../timing.js";
 
 // IIFE wrapper to allow early return
 (function () {
@@ -416,13 +417,13 @@ import { createEvent } from "../events.js";
     }
 
     // Send the page visit start event for the first time
-    pageVisitStart(window.performance.timeOrigin);
+    pageVisitStart(fromMonotonicClock(window.performance.timeOrigin, false));
 
     // Send the page visit stop event on the window unload event,
     // using the timestamp for the unload event on the global
     // monotonic clock 
     window.addEventListener("unload", (event) => {
-        pageVisitStop(window.performance.timeOrigin + event.timeStamp);
+        pageVisitStop(fromMonotonicClock(event.timeStamp, true));
     });
     
 })();

--- a/src/content-scripts/pageTransition.click.content.js
+++ b/src/content-scripts/pageTransition.click.content.js
@@ -11,6 +11,8 @@
  * @module pageTransition.click.content
  */
 
+import { fromMonotonicClock } from "../timing.js";
+
 // IIFE encapsulation to allow early return
 (function () {
 
@@ -59,7 +61,7 @@
             }
 
             // Compute the event timestamp on the shared monotonic clock
-            const timeStamp = window.performance.timeOrigin + event.timeStamp;
+            const timeStamp = fromMonotonicClock(event.timeStamp, true);
 
             // Queue the click for reporting to the background script
             clickTimeStamps.push(timeStamp);

--- a/src/content-scripts/pageTransition.event.content.js
+++ b/src/content-scripts/pageTransition.event.content.js
@@ -7,6 +7,8 @@
  * @module pageTransition.event.content
  */
 
+import { fromMonotonicClock } from "../timing.js";
+
 // IIFE encapsulation to allow early return
 (function () {
 
@@ -37,7 +39,7 @@
     /**
      * The maximum difference, in milliseconds, between the background script timestamp in a History API
      * page load (from `webNavigation.onHistoryStateUpdated`) and the content script page visit start
-     * timestamp (also from `webNavigation.onHistoryStateUpdated`). We compare this values as a heuristic
+     * timestamp (also from `webNavigation.onHistoryStateUpdated`). We compare these values as a heuristic
      * for matching background script events to content script events. While the underlying values are
      * identical, rounding the values when converting them to numbers can lead to off-by-one differences.
      * @constant {number}
@@ -186,7 +188,7 @@
                     return false;
                 }
                 // Calculate the DOMContentLoaded timestamp on the shared monotonic clock from the High Resolution Time and Navigation Timing APIs
-                const PerformanceDOMContentLoadedTimeStamp = window.performance.timeOrigin + performanceNavigationTimingEntries[0].domContentLoadedEventStart;
+                const PerformanceDOMContentLoadedTimeStamp = fromMonotonicClock(performanceNavigationTimingEntries[0].domContentLoadedEventStart, true);
                 if(Math.abs(PerformanceDOMContentLoadedTimeStamp - timeStamp) > maxDOMContentLoadedTimeStampDifference) {
                     return false;
                 }

--- a/src/pageTransition.js
+++ b/src/pageTransition.js
@@ -390,7 +390,7 @@ async function initialize() {
         sendUpdateToContentScript({
             tabId: details.tabId,
             url: details.url,
-            timeStamp: timing.systemToSharedMonotonic(details.timeStamp),
+            timeStamp: timing.fromSystemClock(details.timeStamp),
             webNavigationTimeStamp: details.timeStamp,
             transitionType: webNavigationOnCommittedDetails.transitionType,
             transitionQualifiers: webNavigationOnCommittedDetails.transitionQualifiers,
@@ -411,7 +411,7 @@ async function initialize() {
         sendUpdateToContentScript({
             tabId: details.tabId,
             url: details.url,
-            timeStamp: timing.systemToSharedMonotonic(details.timeStamp),
+            timeStamp: timing.fromSystemClock(details.timeStamp),
             webNavigationTimeStamp: details.timeStamp,
             transitionType: details.transitionType,
             transitionQualifiers: details.transitionQualifiers,


### PR DESCRIPTION
This PR updates WebScience to use one standardized clock, converting between the system clock and High Resolution Time monotonic clock as necessary.