### PR TITLE
Update build references to test references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@
 version: 2.1
 
 jobs:
-  Build:
+  Build test:
     docker:
       - image: cimg/node:14.13.1
     steps:
@@ -27,8 +27,8 @@ jobs:
           name: Install the dependencies
           command: npm install
       - run:
-          name: Build 
-          command: npm run build
+          name: Run build test 
+          command: npm run test
 
 
   Code linting:
@@ -47,5 +47,5 @@ workflows:
   version: 2
   ci:
     jobs:
-      - Build
+      - Build test
       - Code linting

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "scripts": {
         "lint": "eslint .",
-        "build": "cd tests/build/ && rollup -c"
+        "test": "cd tests/build/ && rollup -c"
     },
     "dependencies": {
         "rollup": "^2.41.4",


### PR DESCRIPTION
With the new approach to WebScience assets in #101, there isn't a bundling step for the WebScience library itself. Instead, a study bundles the library from source when bundling the extension. The build that remains in the WebScience repo is just a small test extension. This PR updates terminology in the Node package and CircleCI configuration to avoid ambiguity.