### PR TITLE
bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mozilla/web-science",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "scripts": {
         "lint": "eslint .",
         "build": "cd tests/build/ && rollup -c"


### PR DESCRIPTION
We've released `0.3.0`, this sets `main` to `0.4.0`.