### PR TITLE
run Chrome non-headless with xvfb-run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - node/install-packages
       - run:
           name: Install Firefox, and dependencies for official Google Chrome package
-          command: sudo apt update && sudo apt install firefox default-jre fonts-liberation libgbm1 xdg-utils
+          command: sudo apt update && sudo apt install firefox fonts-liberation libgbm1 xdg-utils xvfb libnspr4 libnss3
       - run:
           name: Download and install official Google Chrome package
           command: wget 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb' && sudo dpkg -i google-chrome-stable_current_amd64.deb

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -eo pipefail
 
+XVFB_RUN() {
+    if hash xvfb-run 2>/dev/null
+    then
+        xvfb-run "$@"
+    else
+        echo "WARN: xvfb-run must be installed to run Chrome with extensions enabled on a headless server"
+        "$@"
+    fi
+}
+
 export PATH=$PATH:./node_modules/.bin
 
 echo "Building test extension..."
@@ -14,4 +24,4 @@ echo "Testing Firefox headless with extension"
 npm run test:integration:jest -- --test_browser=firefox --load_extension=true --headless_mode=true  2>&1 | tee integration.log
 # NOTE Chrome Headless mode does not support extensions, so we use `xvfb` as the display server.
 echo "Testing Chrome non-headless with extension"
-xvfb-run npm run test:integration:jest -- --test_browser=chrome --load_extension=true --headless_mode=false 2>&1 | tee integration.log
+XVFB_RUN npm run test:integration:jest -- --test_browser=chrome --load_extension=true --headless_mode=false 2>&1 | tee integration.log

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -10,8 +10,8 @@ npm install ../../../
 npm install && npm run build && npm run package
 popd
 
-echo "Testing Firefox with extension"
+echo "Testing Firefox headless with extension"
 npm run test:integration:jest -- --test_browser=firefox --load_extension=true --headless_mode=true  2>&1 | tee integration.log
-# FIXME Chrome Headless mode does not support extensions, need to set up a display server if we want this to work.
-# echo "Testing Chrome with extension"
-# npm run test:integration:jest -- --test_browser=chrome --load_extension=true --headless_mode=false 2>&1 | tee integration.log
+# NOTE Chrome Headless mode does not support extensions, so we use `xvfb` as the display server.
+echo "Testing Chrome non-headless with extension"
+xvfb-run npm run test:integration:jest -- --test_browser=chrome --load_extension=true --headless_mode=false 2>&1 | tee integration.log


### PR DESCRIPTION
I figured out a very easy way to run this with Xvfb as a display server! It's also possible to attach a VNC server via an ssh tunnel for debugging, but Selenium also takes screenshots (and it can be run locally) so we shouldn't usually need to.