### PR TITLE
Check for all integration logs

### DIFF
--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -82,7 +82,7 @@ export async function extensionLogsPresent(
         }
       }
       if (!found) {
-        return false;
+        throw new Error(`Failed to find match: ${match} in Chrome logs`);
       }
     }
   } else if (testBrowser === "firefox") {
@@ -95,7 +95,7 @@ export async function extensionLogsPresent(
         found = true;
       }
       if (!found) {
-        return false;
+        throw new Error(`Failed to find match: ${match} in integration.log`);
       }
     }
   } else {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -61,8 +61,8 @@ export async function findAndAct(
  *        WebDriver in use.
  * @param {string} testBrowser
  *        Browser in use.
- * @param {RegExp} message
- *        Message to search for.
+ * @param {Array<RegExp>} message
+ *        Messages to search for. All messages must be present.
  * @returns {Promise<boolean>}
  *        Whether or not the message was found.
  */

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -87,6 +87,7 @@ export async function extensionLogsPresent(
     }
   } else if (testBrowser === "firefox") {
     const fileBuffer = await fs.promises.readFile("./integration.log");
+
     // FIXME it would be more efficient to keep track of where we are in the log vs. re-reading it each time.
     // FIXME this would also make it more like the behavior of Chrome's log interface.
     for (const match of matches) {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -91,11 +91,7 @@ export async function extensionLogsPresent(
     // FIXME it would be more efficient to keep track of where we are in the log vs. re-reading it each time.
     // FIXME this would also make it more like the behavior of Chrome's log interface.
     for (const match of matches) {
-      let found = false;
-      if (match.test(fileBuffer.toString())) {
-        found = true;
-      }
-      if (!found) {
+      if (!match.test(fileBuffer.toString())) {
         throw new Error(`Failed to find match: ${match} in integration.log`);
       }
     }

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -73,29 +73,36 @@ export async function extensionLogsPresent(
 ): Promise<boolean> {
   if (testBrowser === "chrome") {
     const logEntries = await driver.manage().logs().get(logging.Type.BROWSER);
-    let found = false;
-    for (const logEntry of logEntries) {
-      for (const match of matches) {
+
+    for (const match of matches) {
+      let found = false;
+      for (const logEntry of logEntries) {
         if (match.test(logEntry.message)) {
           found = true;
         }
       }
+      if (!found) {
+        return false;
+      }
     }
-    return found;
   } else if (testBrowser === "firefox") {
     const fileBuffer = await fs.promises.readFile("./integration.log");
-    let found = false;
     // FIXME it would be more efficient to keep track of where we are in the log vs. re-reading it each time.
     // FIXME this would also make it more like the behavior of Chrome's log interface.
     for (const match of matches) {
+      let found = false;
       if (match.test(fileBuffer.toString())) {
         found = true;
       }
+      if (!found) {
+        return false;
+      }
     }
-    return found;
   } else {
     throw new Error(`Unsupported browser: ${testBrowser}`);
   }
+
+  return true;
 }
 
 /**

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -67,16 +67,7 @@ async function waitForLogs(matches: RegExp[]) {
   // Switch to original window to read logs.
   await driver.switchTo().window(logWindow);
 
-  // Wait until log message is present, or time out.
-  await driver.wait(
-    async () =>
-      await extensionLogsPresent(
-        driver,
-        testBrowser,
-        matches
-      ),
-    WAIT_FOR_PROPERTY
-  );
+  await extensionLogsPresent(driver, testBrowser, matches);
 
   // Restore focus to test window.
   await driver.switchTo().window(testWindow);

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -49,7 +49,6 @@ let screenshotCount = 0;
 let server;
 
 let logWindow;
-let testWindow;
 
 const PORT = "8000";
 const BASE_URL = `http://localhost:${PORT}`;

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -106,7 +106,6 @@ describe("WebScience Test Extension", function () {
     // Start a new window for tests, the original will be used to collect logs from the extension.
     // Selenium is currently not able to access Chrome extension logs directly, so they are messaged to the
     // original window
-    // TODO save handle
     logWindow = await driver.getWindowHandle();
     await driver.switchTo().newWindow('window');
   });
@@ -159,7 +158,7 @@ describe("WebScience Test Extension", function () {
     );
 
     await waitForLogs([
-      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000\/test1.html)/,
+      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000)/,
       /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test2.html)/
     ]);
   });
@@ -176,7 +175,6 @@ describe("WebScience Test Extension", function () {
     );
 
     await waitForLogs([
-      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000)/,
       /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test1.html)/
     ]);
 
@@ -208,7 +206,6 @@ describe("WebScience Test Extension", function () {
     );
 
     await waitForLogs([
-      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000)/,
       /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000)/
     ]);
 

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -138,17 +138,33 @@ describe("WebScience Test Extension", function () {
       WAIT_FOR_PROPERTY
     );
 
+    await driver.get(`${BASE_URL}/test2.html`);
+    await driver.wait(
+      until.titleIs("Test2"),
+      WAIT_FOR_PROPERTY
+    );
+
     await waitForLogs([
       /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000)/,
-      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test1.html)/
+      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test1.html)/,
+      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000\/test1.html)/,
+      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test2.html)/
     ]);
 
     await driver.navigate().back();
 
     await waitForLogs([
-      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000\/test1.html)/,
-      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000)/
+      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000\/test2.html)/,
+      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test1.html)/
     ]);
+
+    await driver.navigate().forward();
+
+    await waitForLogs([
+      /(WebScienceTest - Page visit stop).*(http:\/\/localhost:8000\/test1.html)/,
+      /(WebScienceTest - Page visit start).*(http:\/\/localhost:8000\/test2.html)/
+    ]);
+
 
     await driver.get(`${BASE_URL}/test2.html`);
     await driver.wait(


### PR DESCRIPTION
The logic in the `extensionLogsPresent` function isn't quite what we want after I looked into it further - previously it just looked for a single regex to match at least one line in the logs, but now we want to pass a list of regexes to match, and only return true if *all* have a match.