### PR TITLE
Fix issue #238, use pagehide not unload listener

### DIFF
--- a/src/content-scripts/pageManager.content.js
+++ b/src/content-scripts/pageManager.content.js
@@ -422,8 +422,7 @@ import { fromMonotonicClock } from "../timing.js";
     // Send the page visit stop event on the window unload event,
     // using the timestamp for the unload event on the global
     // monotonic clock 
-    window.addEventListener("unload", (event) => {
+    window.addEventListener("pagehide", (event) => {
         pageVisitStop(fromMonotonicClock(event.timeStamp, true));
     });
-    
 })();


### PR DESCRIPTION
This seems to work fine in Firefox and (mostly) in Chrome, but it intermittently fails to fire in Chrome.

Per MDN, the [visibilitychange event is preferred](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes), but it does note the back/forward cache behavior. Using `pagehide` when that isn't available is suggested as well.

I think the root cause might be that the back/forward cache doesn't get canceled in Chrome the way it does in Firefox, but I'm having a lot of trouble reproducing it in a test environment. Using `pagehide` instead seems to work when I test sites in the wild, and it still passes the test suite.