### PR TITLE
remove build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "@mozilla/web-science",
     "version": "0.4.0",
     "scripts": {
-        "build": "rollup -c rollup.config.intermediate.js && rollup -c rollup.config.final.js",
         "lint": "eslint .",
         "test:integration:jest": "jest ./tests/integration/",
         "test:integration": "./scripts/integration-test.sh",


### PR DESCRIPTION
WebScience currently exports a rollup plugin for clients to use and doesn't have it's own build process.

Remove the build target for now, we may end up adding it back later.