### PR TITLE
export contentScripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "@types/jest": "^27.4.1",
                 "@types/minimist": "^1.2.2",
                 "@types/selenium-webdriver": "^4.0.18",
-                "chromedriver": "^101.0.0",
+                "chromedriver": "^103.0.0",
                 "eslint": "^8.1.0",
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-mocha": "^10.0.1",
@@ -2913,12 +2913,13 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.14.4"
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/babel-jest": {
@@ -3331,14 +3332,14 @@
             }
         },
         "node_modules/chromedriver": {
-            "version": "101.0.0",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-101.0.0.tgz",
-            "integrity": "sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==",
+            "version": "103.0.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-103.0.0.tgz",
+            "integrity": "sha512-7BHf6HWt0PeOHCzWO8qlnD13sARzr5AKTtG8Csn+czsuAsajwPxdLNtry5GPh8HYFyl+i0M+yg3bT43AGfgU9w==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@testim/chrome-version": "^1.1.2",
-                "axios": "^0.24.0",
+                "axios": "^0.27.2",
                 "del": "^6.0.0",
                 "extract-zip": "^2.0.1",
                 "https-proxy-agent": "^5.0.0",
@@ -11569,12 +11570,13 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.14.4"
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
             }
         },
         "babel-jest": {
@@ -11878,13 +11880,13 @@
             "dev": true
         },
         "chromedriver": {
-            "version": "101.0.0",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-101.0.0.tgz",
-            "integrity": "sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==",
+            "version": "103.0.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-103.0.0.tgz",
+            "integrity": "sha512-7BHf6HWt0PeOHCzWO8qlnD13sARzr5AKTtG8Csn+czsuAsajwPxdLNtry5GPh8HYFyl+i0M+yg3bT43AGfgU9w==",
             "dev": true,
             "requires": {
                 "@testim/chrome-version": "^1.1.2",
-                "axios": "^0.24.0",
+                "axios": "^0.27.2",
                 "del": "^6.0.0",
                 "extract-zip": "^2.0.1",
                 "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@types/jest": "^27.4.1",
         "@types/minimist": "^1.2.2",
         "@types/selenium-webdriver": "^4.0.18",
-        "chromedriver": "^101.0.0",
+        "chromedriver": "^103.0.0",
         "eslint": "^8.1.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^10.0.1",

--- a/src/webScience.js
+++ b/src/webScience.js
@@ -67,3 +67,7 @@ export { workers }
 
 import * as pageTransition from "./pageTransition.js"
 export { pageTransition }
+
+import * as contentScripts from "./contentScripts.js"
+export { contentScripts }
+


### PR DESCRIPTION
I'd like to be able to use this over in https://github.com/mozilla-rally/study-template/pull/267, as a cross-browser way to register content scripts.